### PR TITLE
chore: add Firefox to the list of supported browsers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -877,7 +877,7 @@
     <div class="mx-auto max-w-3xl px-6">
       <p class="text-sm font-semibold text-brand-500">Web flasher</p>
       <h2 class="mt-2 max-w-[30ch] font-serif text-3xl font-medium tracking-tight text-stone-900 text-balance">Flash from your browser.</h2>
-      <p class="mt-3 max-w-[56ch] text-base/7 text-stone-500 text-pretty">Writes firmware over USB using the WebSerial API. Works in Chrome and Edge on desktop. Originally built by <a href="https://github.com/daveallie" target="_blank" rel="noopener" class="font-medium text-brand-500 underline underline-offset-2 hover:text-brand-600">daveallie</a>.</p>
+      <p class="mt-3 max-w-[56ch] text-base/7 text-stone-500 text-pretty">Writes firmware over USB using the WebSerial API. Works in Chrome, Edge and Firefox on desktop. Originally built by <a href="https://github.com/daveallie" target="_blank" rel="noopener" class="font-medium text-brand-500 underline underline-offset-2 hover:text-brand-600">daveallie</a>.</p>
 
       <!-- Browser check -->
       <div id="browser-warning" class="mt-8 hidden rounded-lg border border-amber-200 bg-amber-50/60 px-4 py-3 text-sm/6 text-amber-900">


### PR DESCRIPTION
As of the latest Firefox release, flashing the firmware works  from there too now. I've added it to the list of supported browsers.