### PR TITLE
feat: add documentation tab

### DIFF
--- a/public/docs.html
+++ b/public/docs.html
@@ -1,0 +1,328 @@
+<!DOCTYPE html>
+<html lang="en" class="antialiased">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Documentation - CrossPoint Reader</title>
+  <meta name="description" content="The CrossPoint Reader roadmap and scope: what we're building, what we're not, and how the project evolves toward broader ESP32 e-reader support.">
+  <link rel="icon" type="image/png" href="/favicon.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://rsms.me/inter/inter.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['InterVariable', 'Inter', 'sans-serif'],
+            serif: ['Lora', 'serif'],
+            mono: ['"Geist Mono"', 'monospace'],
+          },
+          colors: {
+            brand: {
+              50: '#f0f5f3',
+              100: '#d6e5de',
+              200: '#b3cfc2',
+              300: '#8fb9a6',
+              400: '#69917D',
+              500: '#4a7a62',
+              600: '#3d6652',
+              700: '#315243',
+              800: '#253e33',
+              900: '#1a2c24',
+            },
+          },
+        },
+      },
+    }
+  </script>
+  <style type="text/tailwindcss">
+    /* Docs sidebar */
+    #docs-sidebar ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }
+    #docs-sidebar button {
+      display: block; width: 100%; text-align: left;
+      padding: 0.5rem 0.75rem; border-radius: 0.5rem; border: none;
+      background: transparent; cursor: pointer;
+      font-size: 0.875rem; line-height: 1.25rem; font-weight: 500;
+      color: #78716c; /* stone-500 */
+      transition: background 150ms, color 150ms;
+    }
+    #docs-sidebar button:hover { background: #f5f5f4; color: #292524; /* stone-100 / stone-800 */ }
+    #docs-sidebar button[aria-current="page"] {
+      background: #f4f4f5; /* zinc-100 */
+      color: #1c1917; /* stone-900 */
+      font-weight: 600;
+    }
+
+    /* Rendered markdown prose */
+    .docs-prose h1 { font-family: 'Lora', serif; font-size: 2.25rem; line-height: 2.5rem; font-weight: 500; color: #1c1917; margin-top: 0; margin-bottom: 1.5rem; letter-spacing: -0.02em; }
+    .docs-prose h2 { font-family: 'Lora', serif; font-size: 1.5rem; line-height: 2rem; font-weight: 500; color: #1c1917; margin-top: 2.5rem; margin-bottom: 1rem; border-bottom: 1px solid #e7e5e4; padding-bottom: 0.5rem; }
+    .docs-prose h3 { font-size: 1.125rem; line-height: 1.5rem; font-weight: 600; color: #292524; margin-top: 2rem; margin-bottom: 0.75rem; }
+    .docs-prose h4, .docs-prose h5, .docs-prose h6 { font-size: 1rem; font-weight: 600; color: #292524; margin-top: 1.5rem; margin-bottom: 0.5rem; }
+    .docs-prose p { margin-top: 0; margin-bottom: 1.25rem; color: #57534e; font-size: 1rem; line-height: 1.75; }
+    .docs-prose ul, .docs-prose ol { margin-top: 0; margin-bottom: 1.25rem; padding-left: 1.5rem; color: #57534e; font-size: 1rem; line-height: 1.75; }
+    .docs-prose li { margin-bottom: 0.375rem; }
+    .docs-prose a { color: #4a7a62; text-decoration: underline; text-underline-offset: 3px; font-weight: 500; }
+    .docs-prose a:hover { color: #3d6652; }
+    .docs-prose code {
+      font-family: 'Geist Mono', monospace;
+      font-size: 0.875em;
+      background: #f5f5f4; border-radius: 0.375rem;
+      padding: 0.2em 0.4em;
+      color: #292524;
+      border: 1px solid #e7e5e4;
+    }
+    .docs-prose pre {
+      background: #1c1917; color: #e7e5e4; border-radius: 0.75rem;
+      padding: 1.25rem; overflow-x: auto;
+      margin-top: 1.5rem; margin-bottom: 1.5rem; font-size: 0.875rem; line-height: 1.6;
+    }
+    .docs-prose pre code { background: transparent; padding: 0; color: inherit; font-size: inherit; border: none; }
+    .docs-prose blockquote {
+      border-left: 4px solid #d6e5de;
+      padding-left: 1.25rem; margin: 1.5rem 0;
+      color: #78716c; font-style: italic;
+    }
+    .docs-prose table { width: 100%; border-collapse: collapse; margin-top: 1.5rem; margin-bottom: 1.5rem; font-size: 0.875rem; }
+    .docs-prose th, .docs-prose td { border: 1px solid #e7e5e4; padding: 0.75rem 1rem; text-align: left; }
+    .docs-prose th { background: #f5f5f4; font-weight: 600; color: #1c1917; }
+    .docs-prose img { max-width: 100%; height: auto; border-radius: 0.75rem; margin: 2rem 0; border: 1px solid #e7e5e4; }
+    .docs-prose hr { border: none; border-top: 1px solid #e7e5e4; margin: 3rem 0; }
+
+    /* Docs loading spinner */
+    .docs-spinner {
+      display: inline-block; width: 1.25rem; height: 1.25rem;
+      border: 2px solid #e7e5e4; border-top-color: #4a7a62;
+      border-radius: 50%; animation: docs-spin 0.6s linear infinite;
+    }
+    @keyframes docs-spin { to { transform: rotate(360deg); } }
+  </style>
+</head>
+<body class="min-h-dvh bg-stone-50 font-sans">
+  <nav class="border-b border-stone-200 bg-white">
+    <div class="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-y-3 px-4 py-3 sm:flex-nowrap sm:px-6">
+      <a href="/" class="order-1 flex min-w-0 shrink-0 items-center gap-2 text-stone-900 no-underline" aria-label="Homepage">
+        <img src="/logo.png" alt="" class="size-7 shrink-0 rounded-md">
+        <span class="text-sm/5 font-medium tracking-tight sm:text-sm/6">
+          <span class="sm:hidden">CrossPoint</span>
+          <span class="hidden sm:inline">CrossPoint Reader</span>
+        </span>
+      </a>
+      <div class="order-3 flex w-full flex-wrap items-center justify-center gap-x-2 gap-y-2 sm:order-2 sm:ml-0 sm:w-auto sm:flex-1 sm:justify-center">
+        <a href="/fonts" class="rounded-md px-2.5 py-1.5 text-xs/5 font-medium text-stone-500 no-underline hover:text-stone-700 sm:text-sm/5">
+          <span class="sm:hidden">Fonts</span>
+          <span class="hidden sm:inline">Font Builder</span>
+        </a>
+        <a href="/roadmap" class="rounded-md px-2.5 py-1.5 text-xs/5 font-medium text-stone-500 no-underline hover:text-stone-700 sm:text-sm/5">Roadmap</a>
+        <a href="/docs.html" class="rounded-md px-2.5 py-1.5 text-xs/5 font-medium text-stone-900 bg-stone-100 no-underline sm:text-sm/5">Docs</a>
+        <a href="#" data-open-download-modal class="rounded-md px-2.5 py-1.5 text-xs/5 font-medium text-stone-500 no-underline hover:text-stone-700 sm:text-sm/5">
+          <span class="sm:hidden">Download</span>
+          <span class="hidden sm:inline">Download Firmware</span>
+        </a>
+        <a href="/#unlock-tool" class="rounded-md px-2.5 py-1.5 text-xs/5 font-medium text-stone-500 no-underline hover:text-stone-700 sm:text-sm/5">
+          <span class="sm:hidden">Locked?</span>
+          <span class="hidden sm:inline">Have a locked device?</span>
+        </a>
+      </div>
+      <a href="https://app.royalty.dev/crosspoint-reader/crosspoint-reader" target="_blank" rel="noopener" class="order-2 inline-flex shrink-0 items-center gap-1.5 rounded-md bg-[#B8953A] py-1.5 pr-3 pl-2 text-xs/5 font-semibold text-white no-underline transition-colors hover:bg-[#9A7A2E] sm:order-3 sm:text-sm/5">
+        <img src="/crown.svg" alt="" class="size-4 brightness-0 invert">
+        <span class="sm:hidden">Fund</span>
+        <span class="hidden sm:inline">Fund CrossPoint</span>
+      </a>
+    </div>
+  </nav>
+
+  <!-- DOCS -->
+  <section class="border-b border-stone-200 bg-white">
+    <div class="mx-auto max-w-6xl px-6 py-12 sm:py-16">
+      
+      <div class="flex flex-col gap-12 md:flex-row">
+        <!-- Sidebar -->
+        <nav id="docs-sidebar" class="w-full shrink-0 md:w-64 border-r border-stone-200 pr-6">
+          <h2 class="mb-6 font-serif text-xl font-medium tracking-tight text-stone-900">Documentation</h2>
+          <p class="text-sm text-stone-400 flex items-center gap-2"><span class="docs-spinner"></span> Loading docs…</p>
+        </nav>
+        
+        <!-- Content -->
+        <article id="docs-content" class="docs-prose min-w-0 flex-1 bg-white md:pl-10">
+          <p class="text-stone-500">Select a document from the sidebar.</p>
+        </article>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="border-t border-stone-200 py-8 bg-stone-50">
+    <div class="mx-auto max-w-3xl px-6">
+      <div class="flex flex-col items-center justify-between gap-4 sm:flex-row">
+        <p class="text-sm text-stone-400">CrossPoint Reader is open-source under the MIT license.</p>
+        <div class="flex gap-4">
+          <a href="https://github.com/crosspoint-reader/crosspoint-reader" target="_blank" rel="noopener" class="text-sm text-stone-400 no-underline hover:text-stone-600">GitHub</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script>
+  (function () {
+
+    // Rewrite image URLs so they load from the main GitHub repository instead of the local server
+    marked.use({
+      walkTokens(token) {
+        if (token.type === 'image') {
+          if (token.href && token.href.startsWith('/')) {
+            token.href = 'https://raw.githubusercontent.com/crosspoint-reader/crosspoint-reader/master' + token.href;
+          } else if (token.href && !token.href.startsWith('http')) {
+            token.href = 'https://raw.githubusercontent.com/crosspoint-reader/crosspoint-reader/master/docs/' + token.href;
+          }
+        }
+      }
+    });
+
+    const sidebar = document.getElementById('docs-sidebar');
+    const content = document.getElementById('docs-content');
+    if (!sidebar || !content) return;
+
+    function toLabel(filename) {
+      return filename
+        .replace(/\.md$/, '')
+        .replace(/[-_]/g, ' ')
+        .replace(/\b\w/g, c => c.toUpperCase());
+    }
+
+    function getDeepLinkDoc() {
+      const hash = window.location.hash; // e.g. "#contributing"
+      // Check if hash matches a specific doc directly, or if it's #docs?doc=...
+      const match = hash.match(/[?&]doc=([^&]+)/);
+      if (match) return decodeURIComponent(match[1]);
+      
+      // Allow direct hash linking on the docs page itself (e.g., /docs.html#contributing)
+      if (hash && hash.length > 1 && !hash.includes('?')) {
+        return decodeURIComponent(hash.substring(1));
+      }
+      return null;
+    }
+
+    function setDeepLink(docName) {
+      history.replaceState(null, '', '#' + encodeURIComponent(docName));
+    }
+
+    async function loadDoc(file, listItems) {
+      content.innerHTML = '<p class="text-stone-400 flex items-center gap-3"><span class="docs-spinner"></span> Loading document…</p>';
+      
+      // Update sidebar visual state
+      if (listItems) {
+        listItems.forEach(li => {
+          const btn = li.querySelector('button');
+          if (btn.dataset.name === file.name) {
+            btn.setAttribute('aria-current', 'page');
+          } else {
+            btn.removeAttribute('aria-current');
+          }
+        });
+      }
+      
+      setDeepLink(file.name.replace(/\.md$/, ''));
+      
+      try {
+        const res = await fetch(file.download_url);
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        let md = await res.text();
+        
+        // Also rewrite raw HTML <img> tags that marked.js walkTokens misses
+        md = md.replace(/<img([^>]+)src=["']([^"']+)["']/gi, (match, before, src) => {
+          let newSrc = src;
+          if (src.startsWith('/')) {
+            newSrc = 'https://raw.githubusercontent.com/crosspoint-reader/crosspoint-reader/master' + src;
+          } else if (!src.startsWith('http') && !src.startsWith('data:')) {
+            newSrc = 'https://raw.githubusercontent.com/crosspoint-reader/crosspoint-reader/master/docs/' + src;
+          }
+          return `<img${before}src="${newSrc}"`;
+        });
+
+        content.innerHTML = marked.parse(md);
+        
+        // Scroll to top of content on mobile when a doc is loaded
+        if (window.innerWidth < 768) {
+          content.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+        
+      } catch (e) {
+        content.innerHTML =
+          '<div class="rounded-lg bg-red-50 p-4 border border-red-100">' +
+          '<h3 class="text-red-800 font-medium text-lg mt-0">Failed to load document</h3>' +
+          '<p class="text-sm text-red-700 mt-2 mb-0">There was an error fetching the content. ' +
+          '<a href="https://github.com/crosspoint-reader/crosspoint-reader/tree/master/docs" target="_blank" rel="noopener" class="font-medium underline underline-offset-2 hover:text-red-900">View it directly on GitHub</a>.</p></div>';
+      }
+    }
+
+    async function init() {
+      // Re-add title if we cleared it
+      sidebar.innerHTML = '<h2 class="mb-6 font-serif text-xl font-medium tracking-tight text-stone-900">Documentation</h2><p class="text-sm text-stone-400 flex items-center gap-2"><span class="docs-spinner"></span> Loading docs…</p>';
+      
+      const files = [
+        { name: 'user_guide.md', label: 'User Guide', download_url: 'https://raw.githubusercontent.com/crosspoint-reader/crosspoint-reader/master/USER_GUIDE.md' },
+        { name: 'scope.md', label: 'Project Scope', download_url: 'https://raw.githubusercontent.com/crosspoint-reader/crosspoint-reader/master/SCOPE.md' },
+        { name: 'webserver.md', label: 'Webserver Interface', download_url: 'https://raw.githubusercontent.com/crosspoint-reader/crosspoint-reader/master/docs/webserver.md' },
+        { name: 'webserver-endpoints.md', label: 'Webserver API Endpoints', download_url: 'https://raw.githubusercontent.com/crosspoint-reader/crosspoint-reader/master/docs/webserver-endpoints.md' },
+        { name: 'troubleshooting.md', label: 'Troubleshooting Guide', download_url: 'https://raw.githubusercontent.com/crosspoint-reader/crosspoint-reader/master/docs/troubleshooting.md' },
+        { name: 'sd-card-fonts.md', label: 'SD Card Fonts', download_url: 'https://raw.githubusercontent.com/crosspoint-reader/crosspoint-reader/master/docs/sd-card-fonts.md' },
+        { name: 'focus-reading.md', label: 'Focus Reading Metrics', download_url: 'https://raw.githubusercontent.com/crosspoint-reader/crosspoint-reader/master/docs/focus-reading.md' }
+      ];
+
+      const ul = document.createElement('ul');
+      const listItems = [];
+
+      files.forEach(file => {
+        const li = document.createElement('li');
+        const btn = document.createElement('button');
+        btn.textContent = file.label || toLabel(file.name);
+        btn.dataset.name = file.name;
+        btn.addEventListener('click', () => loadDoc(file, listItems));
+        li.appendChild(btn);
+        ul.appendChild(li);
+        listItems.push(li);
+      });
+
+      // Re-add header, then the list
+      sidebar.innerHTML = '<h2 class="mb-6 font-serif text-xl font-medium tracking-tight text-stone-900">Documentation</h2>';
+      sidebar.appendChild(ul);
+
+      // Load deep-linked doc, or the first file
+      const deepDoc = getDeepLinkDoc();
+      const target =
+        (deepDoc && files.find(f => f.name.replace(/\.md$/, '') === deepDoc)) ||
+        files[0];
+      if (target) loadDoc(target, listItems);
+    }
+
+    init();
+
+    window.addEventListener('hashchange', () => {
+      // Allow hash navigation to work when clicking internal links or using back button
+      const docName = getDeepLinkDoc();
+      if (docName) {
+        // Trigger a reload of that specific doc if we have the list available
+        const currentActive = sidebar.querySelector('button[aria-current="page"]');
+        if (currentActive && currentActive.dataset.name.replace(/\.md$/, '') === docName) {
+            return; // Already viewing
+        }
+        
+        // Find button to click
+        const targetBtn = sidebar.querySelector(`button[data-name="${docName}.md"]`);
+        if (targetBtn) {
+            targetBtn.click();
+        } else {
+            // Need to fetch again or it's a sub-header hash within the doc
+            // (Sub-header hashing isn't natively supported by this simple renderer without extra work)
+        }
+      }
+    });
+  })();
+  </script>
+</body>
+</html>

--- a/public/docs.html
+++ b/public/docs.html
@@ -117,7 +117,7 @@
         </a>
         <a href="/roadmap" class="rounded-md px-2.5 py-1.5 text-xs/5 font-medium text-stone-500 no-underline hover:text-stone-700 sm:text-sm/5">Roadmap</a>
         <a href="/docs.html" class="rounded-md px-2.5 py-1.5 text-xs/5 font-medium text-stone-900 bg-stone-100 no-underline sm:text-sm/5">Docs</a>
-        <a href="#" data-open-download-modal class="rounded-md px-2.5 py-1.5 text-xs/5 font-medium text-stone-500 no-underline hover:text-stone-700 sm:text-sm/5">
+        <a href="/" class="rounded-md px-2.5 py-1.5 text-xs/5 font-medium text-stone-500 no-underline hover:text-stone-700 sm:text-sm/5">
           <span class="sm:hidden">Download</span>
           <span class="hidden sm:inline">Download Firmware</span>
         </a>
@@ -167,11 +167,29 @@
   </footer>
 
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
   <script>
   (function () {
 
-    // Rewrite image URLs so they load from the main GitHub repository instead of the local server
+    // Rewrite image URLs and generate heading IDs so they can be linked
     marked.use({
+      renderer: {
+        heading(token) {
+          // Support both marked.js v13+ (token object) and older versions (text, depth, raw)
+          const isObj = typeof token === 'object' && token !== null;
+          const text = isObj ? token.text : arguments[0];
+          const depth = isObj ? token.depth : arguments[1];
+          
+          let rawText = text || '';
+          rawText = rawText.replace(/<[^>]+>/g, ''); // strip HTML tags
+          const id = rawText.toLowerCase().trim()
+            .replace(/[^\w\s-]/g, '')
+            .replace(/[\s_-]+/g, '-')
+            .replace(/^-+|-+$/g, '');
+            
+          return `<h${depth} id="${id}">${text}</h${depth}>`;
+        }
+      },
       walkTokens(token) {
         if (token.type === 'image') {
           if (token.href && token.href.startsWith('/')) {
@@ -187,6 +205,50 @@
     const content = document.getElementById('docs-content');
     if (!sidebar || !content) return;
 
+    // Intercept clicks on links inside the docs content to handle routing
+    content.addEventListener('click', (e) => {
+      const a = e.target.closest('a');
+      if (!a) return;
+      
+      const href = a.getAttribute('href');
+      if (!href) return;
+      
+      // Handle in-page anchors
+      if (href.startsWith('#')) {
+        e.preventDefault();
+        const targetId = href.substring(1);
+        const targetElement = document.getElementById(targetId);
+        if (targetElement) {
+          targetElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+        return;
+      }
+      
+      // Handle links to other markdown documents
+      if (href.endsWith('.md') || href.includes('.md#')) {
+        e.preventDefault();
+        let docPath = href;
+        let anchor = '';
+        if (docPath.includes('#')) {
+          const parts = docPath.split('#');
+          docPath = parts[0];
+          anchor = parts[1];
+        }
+        
+        // Extract just the filename without path
+        const parts = docPath.split('/');
+        let filename = parts[parts.length - 1];
+        filename = filename.replace(/\.md$/, '');
+        
+        // Store anchor so we can scroll after the new doc loads
+        if (anchor) {
+          window.sessionStorage.setItem('pendingDocAnchor', anchor);
+        }
+        
+        window.location.hash = '#' + filename;
+      }
+    });
+
     function toLabel(filename) {
       return filename
         .replace(/\.md$/, '')
@@ -196,13 +258,20 @@
 
     function getDeepLinkDoc() {
       const hash = window.location.hash; // e.g. "#contributing"
-      // Check if hash matches a specific doc directly, or if it's #docs?doc=...
-      const match = hash.match(/[?&]doc=([^&]+)/);
-      if (match) return decodeURIComponent(match[1]);
-      
-      // Allow direct hash linking on the docs page itself (e.g., /docs.html#contributing)
-      if (hash && hash.length > 1 && !hash.includes('?')) {
-        return decodeURIComponent(hash.substring(1));
+      try {
+        const match = hash.match(/[?&]doc=([^&]+)/);
+        if (match) return decodeURIComponent(match[1]);
+        
+        if (hash && hash.length > 1 && !hash.includes('?')) {
+          return decodeURIComponent(hash.substring(1));
+        }
+      } catch (e) {
+        // Fallback to unencoded strings if decoding fails
+        const match = hash.match(/[?&]doc=([^&]+)/);
+        if (match) return match[1];
+        if (hash && hash.length > 1 && !hash.includes('?')) {
+          return hash.substring(1);
+        }
       }
       return null;
     }
@@ -244,10 +313,23 @@
           return `<img${before}src="${newSrc}"`;
         });
 
-        content.innerHTML = marked.parse(md);
+        content.innerHTML = DOMPurify.sanitize(marked.parse(md), { ADD_ATTR: ['id', 'target'] });
         
-        // Scroll to top of content on mobile when a doc is loaded
-        if (window.innerWidth < 768) {
+        // Check if there is a pending anchor to scroll to
+        const pendingAnchor = window.sessionStorage.getItem('pendingDocAnchor');
+        if (pendingAnchor) {
+          window.sessionStorage.removeItem('pendingDocAnchor');
+          // Wait a tick for the DOM to update
+          setTimeout(() => {
+            const targetElement = document.getElementById(pendingAnchor);
+            if (targetElement) {
+              targetElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            } else {
+              content.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+          }, 50);
+        } else if (window.innerWidth < 768) {
+          // Scroll to top of content on mobile when a doc is loaded
           content.scrollIntoView({ behavior: 'smooth', block: 'start' });
         }
         

--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://rsms.me/inter/inter.css" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&family=Noto+Serif:wght@400;500;700&family=Noto+Serif+Hebrew:wght@400;700&family=Noto+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <!-- Markdown renderer for Docs tab -->
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
@@ -554,6 +556,7 @@
           <span class="hidden sm:inline">Font Builder</span>
         </a>
         <a href="/roadmap" class="rounded-md px-2.5 py-1.5 text-xs/5 font-medium text-stone-500 no-underline hover:text-stone-700 sm:text-sm/5">Roadmap</a>
+        <a href="/docs.html" class="rounded-md px-2.5 py-1.5 text-xs/5 font-medium text-stone-500 no-underline hover:text-stone-700 sm:text-sm/5">Docs</a>
         <a href="#get-in-touch" class="rounded-md px-2.5 py-1.5 text-xs/5 font-medium text-stone-500 no-underline hover:text-stone-700 sm:text-sm/5">
           <span class="sm:hidden">Contact</span>
           <span class="hidden sm:inline">Get In Touch</span>
@@ -1309,6 +1312,7 @@
     </div>
   </section>
 
+
   <!-- Footer -->
   <footer class="border-t border-stone-200 py-8">
     <div class="mx-auto max-w-3xl px-6">
@@ -1801,5 +1805,8 @@
       });
     })();
   </script>
+
+
+
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -19,8 +19,6 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://rsms.me/inter/inter.css" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&family=Noto+Serif:wght@400;500;700&family=Noto+Serif+Hebrew:wght@400;700&family=Noto+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <!-- Markdown renderer for Docs tab -->
-  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {


### PR DESCRIPTION
## Summary

Automatically fetches and displays documentation from the Crosspoint repository, making it easily accessible within the website. This allows users to find and browse relevant documentation without needing technical knowledge or having to search GitHub manually.


## Screenshot

<img width="1918" height="1011" alt="image" src="https://github.com/user-attachments/assets/a8ee9a96-b4bd-4784-8fb1-2e31f54c0336" />

## Disclaimer

Unlike C/C++, my JS knowledge is near zero, so this PR is "vibe-coded".