### PR TITLE
Add Arabic/Farsi/Urdu interval preset to font builder

### DIFF
--- a/public/fonts.html
+++ b/public/fonts.html
@@ -169,6 +169,8 @@
                   <br><br>
                   <strong class="text-white">Default</strong>: Enables the same general Unicode ranges as the default CrossPoint fonts: English, most European languages, Cyrillic (Russian, Ukrainian, etc.), combining diacritics, math operators, arrows, and common ligatures.
                   <br><br>
+                  <strong class="text-white">Arabic</strong>: Covers Arabic, Farsi, and Urdu letterforms (including Persian/Urdu-specific letters and presentation forms). Note: correct joined rendering depends on the reader's text-shaping pipeline, not just glyph coverage — isolated codepoints alone may render disconnected.
+                  <br><br>
                   <strong class="text-white">Reading (recommended for fiction)</strong>: Includes Default coverage plus extra ranges often seen in English-language fiction and scifi/popsci: broader Latin, Greek terms like λ and φ, box/geometric symbols, supplemental arrows, uncommon dialogue punctuation, CJK quote marks, music notes (♪ ♫ ♬), stars (★), and dingbats (✓).
                   <br><br>
                   <strong class="text-white">Note on Fallback Fonts</strong>: Fallback fonts only fill missing characters. The main family is always checked first, then your fallback family 1, your fallback family 2, and finally the builder's safety-net font. Fallback fonts do not replace characters the main family already has.
@@ -185,6 +187,7 @@
               <label class="flex items-center gap-2 text-sm text-stone-700"><input type="checkbox" name="intervalPreset" value="cyrillic" class="rounded border-stone-300 text-brand-600 focus:ring-brand-500"> Cyrillic</label>
               <label class="flex items-center gap-2 text-sm text-stone-700"><input type="checkbox" name="intervalPreset" value="vietnamese" class="rounded border-stone-300 text-brand-600 focus:ring-brand-500"> Vietnamese</label>
               <label class="flex items-center gap-2 text-sm text-stone-700"><input type="checkbox" name="intervalPreset" value="hebrew" class="rounded border-stone-300 text-brand-600 focus:ring-brand-500"> Hebrew</label>
+              <label class="flex items-center gap-2 text-sm text-stone-700"><input type="checkbox" name="intervalPreset" value="arabic" class="rounded border-stone-300 text-brand-600 focus:ring-brand-500"> Arabic <span class="text-xs text-stone-400">(Farsi, Urdu)</span></label>
               <label class="flex items-center gap-2 text-sm text-stone-700"><input type="checkbox" name="intervalPreset" value="armenian" class="rounded border-stone-300 text-brand-600 focus:ring-brand-500"> Armenian</label>
               <label class="flex items-center gap-2 text-sm text-stone-700"><input type="checkbox" name="intervalPreset" value="georgian" class="rounded border-stone-300 text-brand-600 focus:ring-brand-500"> Georgian</label>
               <label class="flex items-center gap-2 text-sm text-stone-700"><input type="checkbox" name="intervalPreset" value="ethiopic" class="rounded border-stone-300 text-brand-600 focus:ring-brand-500"> Ethiopic</label>

--- a/scripts/font-builder/fontconvert_sdcard.py
+++ b/scripts/font-builder/fontconvert_sdcard.py
@@ -54,6 +54,11 @@ INTERVAL_PRESETS = {
     "greek":       [(0x0370, 0x03FF), (0x1F00, 0x1FFF)],
     "cyrillic":    [(0x0400, 0x04FF), (0x0500, 0x052F)],
     "hebrew":      [(0x0590, 0x05FF), (0xFB1D, 0xFB4F)],
+    "arabic":      [(0x0600, 0x06FF),   # Arabic (incl. Arabic-Indic & Extended digits)
+                    (0x0750, 0x077F),   # Arabic Supplement (Sindhi, extra Urdu/Farsi letters)
+                    (0x08A0, 0x08FF),   # Arabic Extended-A (Quranic/Persian/Urdu extras)
+                    (0xFB50, 0xFDFF),   # Arabic Presentation Forms-A (incl. Persian/Urdu ligature forms)
+                    (0xFE70, 0xFEFF)],  # Arabic Presentation Forms-B (contextual init/medi/fina/isol forms)
     "georgian":    [(0x10A0, 0x10FF), (0x2D00, 0x2D2F)],
     "armenian":    [(0x0530, 0x058F)],
     "ethiopic":    [(0x1200, 0x137F), (0x1380, 0x139F), (0x2D80, 0x2DDF)],

--- a/scripts/font-builder/fontconvert_sdcard.py
+++ b/scripts/font-builder/fontconvert_sdcard.py
@@ -54,11 +54,7 @@ INTERVAL_PRESETS = {
     "greek":       [(0x0370, 0x03FF), (0x1F00, 0x1FFF)],
     "cyrillic":    [(0x0400, 0x04FF), (0x0500, 0x052F)],
     "hebrew":      [(0x0590, 0x05FF), (0xFB1D, 0xFB4F)],
-    "arabic":      [(0x0600, 0x06FF),   # Arabic (incl. Arabic-Indic & Extended digits)
-                    (0x0750, 0x077F),   # Arabic Supplement (Sindhi, extra Urdu/Farsi letters)
-                    (0x08A0, 0x08FF),   # Arabic Extended-A (Quranic/Persian/Urdu extras)
-                    (0xFB50, 0xFDFF),   # Arabic Presentation Forms-A (incl. Persian/Urdu ligature forms)
-                    (0xFE70, 0xFEFF)],  # Arabic Presentation Forms-B (contextual init/medi/fina/isol forms)
+    "arabic":      [(0x0600, 0x06FF), (0x0750, 0x077F), (0x08A0, 0x08FF), (0xFB50, 0xFDF9), (0xFE70, 0xFEFF)],
     "georgian":    [(0x10A0, 0x10FF), (0x2D00, 0x2D2F)],
     "armenian":    [(0x0530, 0x058F)],
     "ethiopic":    [(0x1200, 0x137F), (0x1380, 0x139F), (0x2D80, 0x2DDF)],


### PR DESCRIPTION
- Adds 'arabic' preset in INTERVAL_PRESETS covering Arabic (U+0600-06FF),
  Arabic Supplement (U+0750-077F), Arabic Extended-A (U+08A0-08FF), and
  Arabic Presentation Forms-A/B (U+FB50-FDFF, U+FE70-FEFF) for Persian/
  Urdu letter coverage.
- Adds matching checkbox in the font builder UI.