### PR TITLE
feat: add dictionary to docs page

### DIFF
--- a/src/pages/DocsPage.jsx
+++ b/src/pages/DocsPage.jsx
@@ -50,6 +50,7 @@ const FILES = [
   { name: 'webserver-endpoints.md', label: 'Webserver API Endpoints', download_url: `${RAW_BASE}/docs/webserver-endpoints.md` },
   { name: 'troubleshooting.md', label: 'Troubleshooting Guide', download_url: `${RAW_BASE}/docs/troubleshooting.md` },
   { name: 'sd-card-fonts.md', label: 'SD Card Fonts', download_url: `${RAW_BASE}/docs/sd-card-fonts.md` },
+  { name: 'dictionary.md', label: 'Dictionary', download_url: `${RAW_BASE}/docs/dictionary.md` },
   { name: 'focus-reading.md', label: 'Focus Reading Metrics', download_url: `${RAW_BASE}/docs/focus-reading.md` },
 ]
 

--- a/src/pages/DocsPage.jsx
+++ b/src/pages/DocsPage.jsx
@@ -45,10 +45,10 @@ marked.use({
 
 const FILES = [
   { name: 'user_guide.md', label: 'User Guide', download_url: `${RAW_BASE}/USER_GUIDE.md` },
-  { name: 'scope.md', label: 'Project Scope', download_url: `${RAW_BASE}/SCOPE.md` },
   { name: 'webserver.md', label: 'Webserver Interface', download_url: `${RAW_BASE}/docs/webserver.md` },
   { name: 'webserver-endpoints.md', label: 'Webserver API Endpoints', download_url: `${RAW_BASE}/docs/webserver-endpoints.md` },
   { name: 'troubleshooting.md', label: 'Troubleshooting Guide', download_url: `${RAW_BASE}/docs/troubleshooting.md` },
+  { name: 'fix-bricked-xteink.md', label: 'Recovering a Bricked Xteink', download_url: `${RAW_BASE}/docs/fix-bricked-xteink.md` },
   { name: 'sd-card-fonts.md', label: 'SD Card Fonts', download_url: `${RAW_BASE}/docs/sd-card-fonts.md` },
   { name: 'dictionary.md', label: 'Dictionary', download_url: `${RAW_BASE}/docs/dictionary.md` },
   { name: 'focus-reading.md', label: 'Focus Reading Metrics', download_url: `${RAW_BASE}/docs/focus-reading.md` },


### PR DESCRIPTION
It will fails to load right now, since the documentation is fetched from `master`, and dictionary support is only on `develop` right now.
Merge after release 1.5.0.