### PR TITLE
feat(unlocker): support Biscuit OTA rescue and expose TLS failures

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -1,0 +1,373 @@
+# Biscuit OTA rescue findings
+
+Date verified: 2026-07-27 (Australia/Sydney)
+
+Scope: source analysis and a maintainer-ready `crosspoint-tools` patch. No Biscuit
+source was changed, no firmware or installer was built, and nothing was installed
+on a device.
+
+> [!CAUTION]
+> The leaf certificate currently committed in
+> `unlocker-tool/crates/unlocker-helper/certs/fullchain.pem` expires on
+> **2026-07-30**. Any maintainer-built Windows test installer must use a
+> currently valid `unlocker.crosspointreader.com` certificate, its complete
+> chain, and the maintainers' legitimate matching private key. The private key
+> must not be requested, shared, generated under that domain, or committed.
+
+## Plain-English diagnosis
+
+There are two independent stages.
+
+1. **Stage A - manifest connection:** Biscuit resolves `api.github.com`, opens
+   TLS to port 443, and requests its GitHub release manifest. The old Unlocker
+   logged only requests that completed TLS and reached Axum. It could report
+   that servers were armed before port 443 had actually bound, and its server
+   dependency discarded TLS handshake errors before HTTP middleware. This made
+   the observed "DNS works, Biscuit says Update failed, no manifest request is
+   logged" sequence possible without revealing the cause.
+2. **Stage B - firmware download:** The old generic GitHub response supplied an
+   `http://` firmware URL. Biscuit calls `esp_https_ota` with HTTP OTA disabled
+   in its pinned ESP32-C3 framework configuration, so that URL would fail even
+   after Stage A succeeded. Biscuit needs the HTTPS firmware URL.
+
+This patch fixes the confirmed Stage B mismatch and adds the missing Stage A
+observability. It does not weaken TLS.
+
+## Confirmed Biscuit behavior
+
+The Biscuit checkout used for this verification was commit
+`483ac2951bc98b71bafacb18adbcac99da04bbe0`.
+
+- Manifest URL:
+  `https://api.github.com/repos/yattsu/biscuit/releases/latest`
+  ([source](https://github.com/yattsu/biscuit/blob/483ac2951bc98b71bafacb18adbcac99da04bbe0/src/network/OtaUpdater.cpp#L11)).
+- User-Agent: `Biscuit-ESP32-<version>`
+  ([source](https://github.com/yattsu/biscuit/blob/483ac2951bc98b71bafacb18adbcac99da04bbe0/src/network/OtaUpdater.cpp#L25-L28)).
+- `esp_crt_bundle_attach` remains enabled while certificate hostname/common-name
+  matching is skipped. The chain is still verified
+  ([source](https://github.com/yattsu/biscuit/blob/483ac2951bc98b71bafacb18adbcac99da04bbe0/src/network/OtaUpdater.cpp#L68-L76)).
+- The parser requires a string `tag_name`, an `assets` array, and an asset named
+  exactly `firmware.bin`
+  ([source](https://github.com/yattsu/biscuit/blob/483ac2951bc98b71bafacb18adbcac99da04bbe0/src/network/OtaUpdater.cpp#L122-L156)).
+- Versions are parsed with unchecked `sscanf("%d.%d.%d")` calls into
+  uninitialized integers. A leading `v` is unsafe; `99.9.9` is the required
+  shape
+  ([source](https://github.com/yattsu/biscuit/blob/483ac2951bc98b71bafacb18adbcac99da04bbe0/src/network/OtaUpdater.cpp#L163-L176)).
+- The manifest callback stores only non-chunked response data and allocates from
+  the reported content length. A fixed body with an accurate `Content-Length`
+  is required
+  ([source](https://github.com/yattsu/biscuit/blob/483ac2951bc98b71bafacb18adbcac99da04bbe0/src/network/OtaUpdater.cpp#L30-L58)).
+- Biscuit does not inspect the manifest HTTP status before parsing the body
+  ([source](https://github.com/yattsu/biscuit/blob/483ac2951bc98b71bafacb18adbcac99da04bbe0/src/network/OtaUpdater.cpp#L103-L126)).
+- Transport, TLS, client setup, JSON, missing-asset, OTA begin, incomplete
+  transfer, and OTA finish errors are collapsed into the generic UI failure
+  ([result definitions](https://github.com/yattsu/biscuit/blob/483ac2951bc98b71bafacb18adbcac99da04bbe0/src/network/OtaUpdater.h#L16-L24),
+  [UI mapping](https://github.com/yattsu/biscuit/blob/483ac2951bc98b71bafacb18adbcac99da04bbe0/src/activities/settings/OtaUpdateActivity.cpp#L29-L46)).
+
+## Confirmed Unlocker behavior before this patch
+
+- DNS already spoofs `api.github.com` and
+  `unlocker.crosspointreader.com` and logs DNS query details
+  (`unlocker-tool/crates/unlocker-core/src/dns.rs:23-39,122-151`).
+- The GitHub-shaped route already matches
+  `/repos/{owner}/{repo}/releases/latest`
+  (`unlocker-tool/crates/unlocker-core/src/http.rs`).
+- The generic manifest already used the bare tag `99.9.9`, the selected
+  firmware's byte size, and `firmware.bin` for non-CrossInk repositories.
+- Biscuit previously followed the generic HTTP firmware URL. Only INX and
+  CrossPet normally selected HTTPS.
+- Firmware responses already have an explicit `Content-Length` and log stream
+  completion or early disconnect.
+- HTTP and HTTPS binds happened inside detached tasks. "manifest servers up"
+  was logged immediately after spawning them, before either bind result was
+  known.
+- `axum-server` 0.8.0 handles acceptor results with `if let Ok(...)`; TLS
+  errors were discarded before the Axum request logger.
+- Rustls uses one certificate chain for all SNI names. There is no application
+  SNI rejection rule.
+- The helper embeds `fullchain.pem` and compile-time includes an ignored,
+  non-public `privkey.pem`
+  (`unlocker-tool/crates/unlocker-helper/src/servers.rs:19-20`,
+  `unlocker-tool/.gitignore:12`).
+- The source starts Windows Mobile Hotspot but does not create Windows Firewall
+  rules. The inspected machine currently has enabled Public-profile inbound
+  allow rules for the installed helper on TCP and UDP, so Firewall is not the
+  leading explanation on that machine.
+
+## What this patch changes
+
+### Stage A diagnostics
+
+- HTTP port 80 and HTTPS port 443 are synchronously bound before `start`
+  returns success (`unlocker-tool/crates/unlocker-core/src/http.rs:798-809,895-928`).
+- Bind failures are logged with server name, address, and the OS error, then
+  returned to the helper/UI.
+- Every accepted HTTPS TCP connection logs client and local addresses before
+  the TLS handshake (`http.rs:147-172`).
+- The TLS wrapper logs handshake start, success, exact available failure error,
+  negotiated TLS version, cipher, ALPN, and SNI on successful handshakes
+  (`http.rs:174-220`).
+- `axum-server` does not expose its partially parsed ClientHello after a failed
+  `RustlsAcceptor` future. The failure record therefore says
+  `sni_available=false`; it does not claim a failed-handshake SNI value.
+- Server futures are supervised. Unexpected clean exits, returned I/O errors,
+  panics, cancellations, and shutdown join errors are surfaced
+  (`http.rs:812-842`).
+- Existing HTTP method, Host, path, and User-Agent logging remains in place.
+  Biscuit responses now additionally log the exact JSON and byte length.
+
+Expected Stage A log order for a successful request:
+
+1. `server socket bound` for HTTP and HTTPS
+2. `manifest servers ready; both sockets bound`
+3. `incoming HTTPS TCP connection`
+4. `TLS handshake start`
+5. `TLS handshake success` with SNI/TLS/cipher/ALPN
+6. `http request` with method/Host/path/User-Agent
+7. `device requested update via GitHub API (latest)`
+8. `serving fixed-length Biscuit manifest response`
+
+If the sequence stops earlier, the new last record identifies the stage.
+
+### Biscuit manifest
+
+Only a repository name equal to `biscuit` selects this response:
+
+```json
+{
+  "tag_name": "99.9.9",
+  "name": "CrossPoint <selected version>",
+  "assets": [
+    {
+      "name": "firmware.bin",
+      "browser_download_url": "https://unlocker.crosspointreader.com/firmware/firmware.bin",
+      "size": "<exact selected firmware byte size>",
+      "content_type": "application/octet-stream"
+    }
+  ]
+}
+```
+
+The actual `size` is a JSON number. The response is serialized once and sent
+with explicit `Content-Type: application/json` and exact `Content-Length`. It
+does not set `Transfer-Encoding` (`http.rs:554-590,646-694`).
+
+Stock Xteink, CrossPoint, CrossInk, INX, CrossPet (including its HTTP toggle),
+and CPR-vCodex keep their existing behavior. Tests cover those branches.
+
+### Diagnostic chip ID
+
+The image metadata logger incorrectly identified chip ID 5 as ESP32-S3 and 6
+as ESP32-C3. Espressif assigns ID 5 to ESP32-C3 and ID 9 to ESP32-S3. The map
+and focused test are corrected (`http.rs:86-141,1125-1129`).
+
+## Escape Hatch safety result
+
+No catalog code was changed and no duplicate release was added.
+
+The existing live release and UI entry were verified:
+
+- worker catalog ID: `recovery-escape-hatch`
+  (`worker/index.ts:3470-3488`)
+- namespaced UI ID: `xteink:recovery-escape-hatch`
+  (`unlocker-tool/app/src/screens/Firmware.tsx:71-77,218-228`)
+- supported devices: X3 and X4
+- current verified image on 2026-07-27: 446,736 bytes, SHA-256
+  `843c1f2e4f765f2010728637ed5d77e44cbeb6e68fb170365437ec7f4f8409f4`
+- normal ESP application image, ESP32-C3 chip ID 5, secure version 0
+- substantially smaller than the `0x640000` OTA application slot
+- same 16 MB dual-OTA partition layout as Biscuit and CrossInk
+- browses `.bin` files on SD, validates the application image, writes the
+  inactive application slot, updates OTA selection data, and reboots
+
+It does not require or supply a bootloader, partition-table image, NVS image,
+or full-flash image.
+
+## Validation
+
+Completed locally without any production private key:
+
+- `cargo fmt -p unlocker-core -- --check`
+- `cargo test --locked -p unlocker-core` - 4 passed, 0 failed
+- `cargo check --locked -p unlocker-core`
+- `cargo clippy --locked -p unlocker-core --all-targets` - completed with three
+  pre-existing warnings in `transport.rs` and `types.rs`; no warning points to
+  the changed HTTP/TLS code
+- `git diff --check`
+
+The full workspace `cargo fmt --all -- --check` reports pre-existing format
+drift in `unlocker-tool/app/src-tauri/src/lib.rs`. That unrelated file was not
+reformatted or included in this focused patch; the modified Rust crate passes
+its scoped format check.
+
+Strict Clippy with `-D warnings` is blocked by the same three unrelated
+pre-existing warnings (two unnecessary casts in `transport.rs` and a derivable
+`Default` implementation in `types.rs`). Those files were left unchanged.
+
+Not run:
+
+- `cargo check/test -p unlocker-helper`: the public checkout intentionally
+  lacks `unlocker-tool/crates/unlocker-helper/certs/privkey.pem`, which is
+  required by `include_str!` at compile time.
+- Windows installer build: only maintainers with the legitimate certificate
+  infrastructure can produce a device-usable build.
+- Frontend checks: no frontend source or configuration changed.
+- Device OTA/install: deliberately out of scope for this patch run.
+
+No temporary key, self-signed replacement, TLS bypass, bootloader image,
+partition-table image, or firmware image was created.
+
+## Maintainer testing instructions
+
+The maintainer-produced Windows test installer must contain a currently valid
+certificate for `unlocker.crosspointreader.com`, the complete chain, and the
+matching legitimate private key.
+
+1. Select X4.
+2. Select the verified Escape Hatch recovery image.
+3. Start the hotspot and confirm the log reports both port 80 and port 443 as
+   bound before it reports the servers ready.
+4. Connect the Biscuit device to the hotspot.
+5. Confirm Biscuit resolves `api.github.com` to `192.168.137.1`.
+6. Run **Check for Updates once**.
+7. Save the complete helper log. Confirm it contains either the successful
+   Stage A sequence above or an exact bind/TCP/TLS failure.
+8. For a successful request, verify the logged Biscuit JSON has one
+   `firmware.bin`, exact selected byte size, bare `99.9.9`, and the HTTPS URL.
+9. Do **not** confirm installation on the device until the selected application
+   image, hash, size, ESP32-C3 chip ID, and manifest have all been reviewed.
+
+## Unresolved risks
+
+- The currently installed helper binary does not contain this logging; a
+  maintainer-built test installer is required.
+- The exact old Stage A failure remains unknown until a request is captured
+  with the new diagnostics.
+- The committed certificate is close to expiry and must not be used for a test
+  after its validity window.
+- SNI is available from the chosen wrapper only after a successful Rustls
+  handshake. Failed handshakes report the exact available error but no SNI.
+- A successful manifest response does not itself prove that the selected
+  firmware is safe. Maintainers must verify the image before allowing install.
+- No device installation was performed as part of this work.
+
+## Draft pull request
+
+### Title
+
+`feat(unlocker): support Biscuit OTA rescue and expose TLS failures`
+
+### Body
+
+```markdown
+## Summary
+
+Adds an explicit, fixed-length GitHub release response for Biscuit and exposes
+the TCP/TLS failures that currently occur before Axum request logging.
+
+## Why
+
+Biscuit requests:
+
+`https://api.github.com/repos/yattsu/biscuit/releases/latest`
+
+It requires a bare numeric tag, an exact `firmware.bin` asset, and a
+non-chunked manifest with an accurate `Content-Length`. Its `esp_https_ota`
+configuration rejects the generic HTTP firmware URL previously returned by the
+Unlocker.
+
+The old listener startup also reported "servers up" before the port 80/443 bind
+results were known, while axum-server discarded TLS accept errors before HTTP
+middleware. This made pre-manifest failures invisible.
+
+## Changes
+
+- bind HTTP/HTTPS sockets before reporting readiness
+- return and log bind errors clearly
+- log HTTPS TCP accepts, client address, TLS start/result, negotiated
+  TLS/cipher/ALPN, and successful-handshake SNI
+- supervise server task exits and failures
+- add Biscuit-only `99.9.9` / `firmware.bin` manifest using the exact selected
+  size and HTTPS firmware URL
+- explicitly set Biscuit JSON `Content-Length`; no chunked transfer encoding
+- preserve stock Xteink, CrossPoint, CrossInk, INX, CrossPet, and CPR-vCodex
+  behavior
+- correct ESP32-C3 image chip ID from 6 to 5 (ESP32-S3 is 9)
+- add focused response and compatibility tests
+- document Stage A/Stage B findings and Escape Hatch verification
+
+## Validation
+
+- `cargo fmt -p unlocker-core -- --check`
+- `cargo test --locked -p unlocker-core` (4 passed)
+- `cargo check --locked -p unlocker-core`
+- `git diff --check`
+
+Full helper/installer builds were not run because the public repository omits
+the production `privkey.pem`. No replacement key or TLS bypass was introduced.
+
+## Certificate action required
+
+The committed leaf certificate expires on 2026-07-30. Any Windows test build
+must use a currently valid `unlocker.crosspointreader.com` certificate, complete
+chain, and the maintainers' legitimate matching private key.
+
+## Maintainer test request
+
+Please produce a Windows test installer with the renewed legitimate
+certificate infrastructure, run one Biscuit update check without confirming
+installation, and attach the complete helper log. Please also confirm the
+current X4 Escape Hatch catalog image/hash before device installation.
+```
+
+## Draft maintainer issue
+
+### Title
+
+`Request: Biscuit OTA rescue review, renewed-cert Windows build, and TLS diagnostic test`
+
+### Body
+
+```markdown
+## Request
+
+Please review the Biscuit OTA rescue patch and produce a Windows test installer
+using the legitimate Unlocker TLS private key and a currently valid
+`unlocker.crosspointreader.com` certificate with its complete chain.
+
+## Urgent certificate note
+
+The leaf certificate currently committed in `fullchain.pem` expires on
+2026-07-30. A test installer must not be issued with an expired or nearly
+expired chain. Please renew it through the project's normal certificate
+infrastructure. Do not publish the private key.
+
+## What needs confirmation
+
+1. Review the Biscuit-only manifest contract:
+   - `tag_name` exactly `99.9.9`
+   - exactly one `firmware.bin` asset
+   - exact selected firmware size
+   - `https://unlocker.crosspointreader.com/firmware/firmware.bin`
+   - explicit JSON `Content-Length`, no chunked transfer encoding
+2. Confirm the current Escape Hatch catalog image is the intended X4/ESP32-C3
+   application-only rescue image and confirm its published hash.
+3. Build a Windows test installer with the legitimate renewed certificate/key.
+4. Run one Biscuit **Check for Updates** attempt and collect the complete helper
+   log without confirming installation.
+5. Verify the log shows socket bind results, incoming client address, TLS
+   handshake start/result, successful-handshake SNI/TLS/cipher/ALPN, HTTP
+   method/Host/path/User-Agent, exact manifest JSON, and any firmware stream
+   completion or early disconnect.
+
+## Why diagnostics are needed
+
+The observed device resolves `api.github.com` to `192.168.137.1` but reports
+`Update failed` without an HTTP manifest request in the old helper log. The old
+server could report ready before port 443 bound, and TLS accept errors were
+discarded before Axum middleware. The patch makes those stages observable but
+the original failure cannot be identified until tested in a maintainer build.
+
+No USB recovery, TLS weakening, self-signed replacement, private-key sharing,
+or bootloader/partition-table changes are requested.
+```

--- a/unlocker-tool/Cargo.lock
+++ b/unlocker-tool/Cargo.lock
@@ -5524,6 +5524,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
+ "tower",
  "tracing",
  "uuid",
  "windows-sys 0.59.0",

--- a/unlocker-tool/crates/unlocker-core/Cargo.toml
+++ b/unlocker-tool/crates/unlocker-core/Cargo.toml
@@ -31,6 +31,9 @@ axum-server = { version = "0.8", features = ["tls-rustls"] }
 rustls-pemfile = { workspace = true }
 x509-parser = "0.18"
 
+[dev-dependencies]
+tower = { workspace = true, features = ["util"] }
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation",

--- a/unlocker-tool/crates/unlocker-core/src/http.rs
+++ b/unlocker-tool/crates/unlocker-core/src/http.rs
@@ -905,12 +905,6 @@ pub async fn start(cfg: Arc<ServerConfig>, cert: &SelfSignedCert) -> anyhow::Res
     let app_http = app.clone();
     let h1 = http_handle.clone();
     let http_server = axum_server::from_tcp(http_listener)?.handle(h1);
-    let http_shutdown = shutdown_requested.clone();
-    let http = tokio::spawn(supervise_server(
-        "HTTP",
-        http_shutdown,
-        http_server.serve(app_http.into_make_service()),
-    ));
 
     let app_https = app.clone();
     let h2 = https_handle.clone();
@@ -918,6 +912,13 @@ pub async fn start(cfg: Arc<ServerConfig>, cert: &SelfSignedCert) -> anyhow::Res
     let https_server = axum_server::from_tcp(https_listener)?
         .acceptor(https_acceptor)
         .handle(h2);
+
+    let http_shutdown = shutdown_requested.clone();
+    let http = tokio::spawn(supervise_server(
+        "HTTP",
+        http_shutdown,
+        http_server.serve(app_http.into_make_service()),
+    ));
     let https_shutdown = shutdown_requested.clone();
     let https = tokio::spawn(supervise_server(
         "HTTPS",

--- a/unlocker-tool/crates/unlocker-core/src/http.rs
+++ b/unlocker-tool/crates/unlocker-core/src/http.rs
@@ -1,15 +1,16 @@
 //! Manifest server.
 //!
 //! Two listeners on the bridge IP:
-//!   * port 80   — plain HTTP. Serves the stock updater path.
-//!   * port 443  — HTTPS with a self-signed cert for the spoofed API hostname.
-//!                 Handles the CrossPoint GitHub API spoof and firmware asset.
+//! * port 80 — plain HTTP. Serves the stock updater path.
+//! * port 443 — HTTPS with the bundled Unlocker certificate chain. Handles the
+//!   GitHub API spoof and firmware asset.
 //!
 //! The CrossPoint OTA path should look like a plain fixed-length HTTPS asset
 //! download, not a chunked application stream.
 
 use crate::cert::SelfSignedCert;
 use crate::types::{Locale, Model};
+use anyhow::Context as _;
 use axum::{
     body::Body,
     extract::{Path as AxPath, Query, State},
@@ -19,16 +20,26 @@ use axum::{
     routing::{get, post},
     Router,
 };
-use axum_server::tls_rustls::RustlsConfig;
+use axum_server::{
+    accept::Accept,
+    tls_rustls::{RustlsAcceptor, RustlsConfig},
+};
 use bytes::Bytes;
 use futures::Stream;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::net::{IpAddr, SocketAddr};
+use std::future::Future;
+use std::io;
+use std::net::{IpAddr, SocketAddr, TcpListener};
 use std::path::PathBuf;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use std::task::{Context, Poll};
+use tokio::net::TcpStream;
+use tokio_rustls::server::TlsStream;
 
 /// Body stream that yields the firmware in fixed-size chunks while logging
 /// progress and final state. The Drop impl is the key piece: it tells us
@@ -75,16 +86,9 @@ fn log_image_metadata(bytes: &[u8]) {
     let magic = bytes[0];
     let segment_count = bytes[1];
     let chip_id = u16::from_le_bytes([bytes[12], bytes[13]]);
-    let chip_name = match chip_id {
-        0x0000 => "ESP32",
-        0x0002 => "ESP32-S2",
-        0x0005 => "ESP32-S3",
-        0x0006 => "ESP32-C3",
-        0x0009 => "ESP32-S2-Beta",
-        0x000C => "ESP32-C2",
-        0x000D => "ESP32-C6",
-        0x0010 => "ESP32-H2",
-        other => return tracing::warn!(magic, segment_count, chip_id = other, "unknown chip_id"),
+    let Some(chip_name) = esp_chip_name(chip_id) else {
+        tracing::warn!(magic, segment_count, chip_id, "unknown chip_id");
+        return;
     };
 
     let desc = &bytes[32..32 + 256];
@@ -121,6 +125,100 @@ fn log_image_metadata(bytes: &[u8]) {
 fn cstr_field(b: &[u8]) -> String {
     let end = b.iter().position(|&c| c == 0).unwrap_or(b.len());
     String::from_utf8_lossy(&b[..end]).into_owned()
+}
+
+fn esp_chip_name(chip_id: u16) -> Option<&'static str> {
+    match chip_id {
+        0x0000 => Some("ESP32"),
+        0x0002 => Some("ESP32-S2"),
+        0x0005 => Some("ESP32-C3"),
+        0x0009 => Some("ESP32-S3"),
+        0x000C => Some("ESP32-C2"),
+        0x000D => Some("ESP32-C6"),
+        0x0010 => Some("ESP32-H2"),
+        _ => None,
+    }
+}
+
+/// Adds connection and handshake diagnostics around axum-server's Rustls
+/// acceptor. axum-server intentionally discards acceptor errors before the
+/// HTTP middleware runs, so failures must be logged here.
+#[derive(Clone)]
+struct LoggingTlsAcceptor {
+    inner: RustlsAcceptor,
+}
+
+impl LoggingTlsAcceptor {
+    fn new(config: RustlsConfig) -> Self {
+        Self {
+            inner: RustlsAcceptor::new(config),
+        }
+    }
+}
+
+impl<S> Accept<TcpStream, S> for LoggingTlsAcceptor
+where
+    S: Send + 'static,
+{
+    type Stream = TlsStream<TcpStream>;
+    type Service = S;
+    type Future =
+        Pin<Box<dyn Future<Output = io::Result<(Self::Stream, Self::Service)>> + Send + 'static>>;
+
+    fn accept(&self, stream: TcpStream, service: S) -> Self::Future {
+        let client = stream.peer_addr().ok();
+        let local = stream.local_addr().ok();
+        tracing::info!(?client, ?local, "incoming HTTPS TCP connection");
+        tracing::info!(?client, "TLS handshake start");
+
+        let handshake = self.inner.accept(stream, service);
+        Box::pin(async move {
+            match handshake.await {
+                Ok((tls_stream, service)) => {
+                    let connection = tls_stream.get_ref().1;
+                    let tls_version = connection
+                        .protocol_version()
+                        .map(|version| format!("{version:?}"))
+                        .unwrap_or_else(|| "unknown".to_string());
+                    let cipher = connection
+                        .negotiated_cipher_suite()
+                        .map(|suite| format!("{:?}", suite.suite()))
+                        .unwrap_or_else(|| "unknown".to_string());
+                    let alpn = connection
+                        .alpn_protocol()
+                        .map(|value| String::from_utf8_lossy(value).into_owned())
+                        .unwrap_or_else(|| "not negotiated".to_string());
+                    let sni = connection
+                        .server_name()
+                        .map(str::to_owned)
+                        .unwrap_or_else(|| "not supplied".to_string());
+
+                    tracing::info!(
+                        ?client,
+                        %sni,
+                        %tls_version,
+                        %cipher,
+                        %alpn,
+                        "TLS handshake success"
+                    );
+                    Ok((tls_stream, service))
+                }
+                Err(error) => {
+                    // RustlsAcceptor does not expose the partially parsed
+                    // ClientHello when its handshake future fails, so SNI is
+                    // only available on the successful path above.
+                    tracing::error!(
+                        ?client,
+                        error = %error,
+                        error_debug = ?error,
+                        sni_available = false,
+                        "TLS handshake failed"
+                    );
+                    Err(error)
+                }
+            }
+        })
+    }
 }
 
 impl Stream for LoggedFirmwareStream {
@@ -236,10 +334,7 @@ pub fn router(cfg: Arc<ServerConfig>) -> Router {
         // franssjz.github.io/cpr-vcodex/firmware/manifest.json. Schema is
         // custom (FirmwareManifestJsonParser only reads top-level `version`,
         // `downloadUrl`, `size`), not the GitHub releases shape.
-        .route(
-            "/cpr-vcodex/firmware/manifest.json",
-            get(vcodex_manifest),
-        )
+        .route("/cpr-vcodex/firmware/manifest.json", get(vcodex_manifest))
         .fallback(catch_all)
         .layer(middleware::from_fn(log_request))
         .with_state(cfg)
@@ -460,7 +555,7 @@ async fn github_releases_latest(
     State(cfg): State<Arc<ServerConfig>>,
     AxPath((owner, repo)): AxPath<(String, String)>,
     headers: HeaderMap,
-) -> Json<serde_json::Value> {
+) -> Response {
     tracing::info!(
         host = ?headers.get(header::HOST),
         user_agent = ?headers.get(header::USER_AGENT),
@@ -469,7 +564,28 @@ async fn github_releases_latest(
     );
 
     cfg.on_manifest_request.notify_one();
-    Json(build_release(&cfg, &repo))
+    let release = build_release(&cfg, &repo);
+    if repo.eq_ignore_ascii_case("biscuit") {
+        biscuit_manifest_response(release)
+    } else {
+        Json(release).into_response()
+    }
+}
+
+fn biscuit_manifest_response(release: serde_json::Value) -> Response {
+    let body = serde_json::to_vec(&release).expect("serializing a JSON value cannot fail");
+    tracing::info!(
+        content_length = body.len(),
+        json = %String::from_utf8_lossy(&body),
+        "serving fixed-length Biscuit manifest response"
+    );
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::CONTENT_LENGTH, body.len())
+        .body(Body::from(body))
+        .expect("static Biscuit response headers are valid")
 }
 
 /// Spoofs `GET /repos/{owner}/{repo}/releases`.
@@ -530,9 +646,10 @@ fn build_release(cfg: &ServerConfig, repo: &str) -> serde_json::Value {
     // `esp_crt_bundle_attach` (chain-only validation, no hostname enforcement).
     let is_inx = repo.eq_ignore_ascii_case("inx");
     let is_crosspet = repo.eq_ignore_ascii_case("crosspet");
+    let is_biscuit = repo.eq_ignore_ascii_case("biscuit");
 
     let crosspet_http = is_crosspet && cfg.crosspet_http;
-    let scheme = if (is_inx || is_crosspet) && !crosspet_http {
+    let scheme = if is_biscuit || (is_inx || is_crosspet) && !crosspet_http {
         "https"
     } else {
         "http"
@@ -574,7 +691,7 @@ fn build_release(cfg: &ServerConfig, repo: &str) -> serde_json::Value {
     // Use a very high version so the device always considers it newer.
     // CrossPoint's version check uses sscanf("%d.%d.%d") so this parses
     // as 99.9.9 which is greater than any real version.
-    tracing::info!(%download_url, %tag, is_crossink, is_inx, is_crosspet, crosspet_http, "serving manifest");
+    tracing::info!(%download_url, %tag, is_biscuit, is_crossink, is_inx, is_crosspet, crosspet_http, "serving manifest");
 
     serde_json::json!({
         "tag_name": tag,
@@ -654,14 +771,70 @@ pub struct ServerHandles {
     pub https: tokio::task::JoinHandle<std::io::Result<()>>,
     pub http_handle: axum_server::Handle<SocketAddr>,
     pub https_handle: axum_server::Handle<SocketAddr>,
+    shutdown_requested: Arc<AtomicBool>,
 }
 
 impl ServerHandles {
     pub async fn shutdown(self) {
+        self.shutdown_requested.store(true, Ordering::SeqCst);
         self.http_handle.shutdown();
         self.https_handle.shutdown();
-        let _ = self.http.await;
-        let _ = self.https.await;
+        report_server_join("HTTP", self.http.await);
+        report_server_join("HTTPS", self.https.await);
+    }
+}
+
+fn report_server_join(
+    server: &'static str,
+    result: Result<io::Result<()>, tokio::task::JoinError>,
+) {
+    match result {
+        Ok(Ok(())) => tracing::info!(server, "server task joined"),
+        Ok(Err(error)) => tracing::error!(server, error = %error, "server task returned an error"),
+        Err(error) => tracing::error!(server, error = %error, "server supervisor task failed"),
+    }
+}
+
+fn bind_server_listener(addr: SocketAddr, server: &'static str) -> anyhow::Result<TcpListener> {
+    let listener = TcpListener::bind(addr)
+        .map_err(|error| {
+            tracing::error!(server, %addr, error = %error, "failed to bind server socket");
+            error
+        })
+        .with_context(|| format!("failed to bind {server} server socket on {addr}"))?;
+    listener
+        .set_nonblocking(true)
+        .with_context(|| format!("failed to set {server} listener on {addr} nonblocking"))?;
+    tracing::info!(server, %addr, "server socket bound");
+    Ok(listener)
+}
+
+async fn supervise_server<F>(
+    server: &'static str,
+    shutdown_requested: Arc<AtomicBool>,
+    future: F,
+) -> io::Result<()>
+where
+    F: Future<Output = io::Result<()>> + Send + 'static,
+{
+    match tokio::spawn(future).await {
+        Ok(result) => {
+            let expected = shutdown_requested.load(Ordering::SeqCst);
+            match (&result, expected) {
+                (Ok(()), true) => tracing::info!(server, "server stopped after shutdown request"),
+                (Ok(()), false) => tracing::warn!(server, "server task terminated unexpectedly"),
+                (Err(error), _) => {
+                    tracing::error!(server, error = %error, expected, "server task terminated with error")
+                }
+            }
+            result
+        }
+        Err(error) => {
+            tracing::error!(server, error = %error, "server task panicked or was cancelled");
+            Err(io::Error::other(format!(
+                "{server} server task panicked or was cancelled: {error}"
+            )))
+        }
     }
 }
 
@@ -670,19 +843,6 @@ pub async fn start(cfg: Arc<ServerConfig>, cert: &SelfSignedCert) -> anyhow::Res
 
     let http_addr = SocketAddr::new(cfg.bind_ip, 80);
     let https_addr = SocketAddr::new(cfg.bind_ip, 443);
-
-    let http_handle = axum_server::Handle::new();
-    let https_handle = axum_server::Handle::new();
-
-    // Plain HTTP listener.
-    let app_http = app.clone();
-    let h1 = http_handle.clone();
-    let http = tokio::spawn(async move {
-        axum_server::bind(http_addr)
-            .handle(h1)
-            .serve(app_http.into_make_service())
-            .await
-    });
 
     // HTTPS listener. Force HTTP/1.1 only — ESP32's esp_http_client
     // doesn't support HTTP/2, and ALPN negotiation can cause issues.
@@ -730,21 +890,241 @@ pub async fn start(cfg: Arc<ServerConfig>, cert: &SelfSignedCert) -> anyhow::Res
         .with_single_cert(certs, key)?;
     server_config.alpn_protocols = vec![b"http/1.1".to_vec()];
     let tls = RustlsConfig::from_config(std::sync::Arc::new(server_config));
+
+    // Bind both privileged sockets synchronously. Returning from this function
+    // now proves that both listeners exist; the UI must not report "armed" on
+    // the strength of spawned tasks that have not attempted their binds yet.
+    let http_listener = bind_server_listener(http_addr, "HTTP")?;
+    let https_listener = bind_server_listener(https_addr, "HTTPS")?;
+
+    let http_handle = axum_server::Handle::new();
+    let https_handle = axum_server::Handle::new();
+    let shutdown_requested = Arc::new(AtomicBool::new(false));
+
+    // Plain HTTP listener.
+    let app_http = app.clone();
+    let h1 = http_handle.clone();
+    let http_server = axum_server::from_tcp(http_listener)?.handle(h1);
+    let http_shutdown = shutdown_requested.clone();
+    let http = tokio::spawn(supervise_server(
+        "HTTP",
+        http_shutdown,
+        http_server.serve(app_http.into_make_service()),
+    ));
+
     let app_https = app.clone();
     let h2 = https_handle.clone();
-    let https = tokio::spawn(async move {
-        axum_server::bind_rustls(https_addr, tls)
-            .handle(h2)
-            .serve(app_https.into_make_service())
-            .await
-    });
+    let https_acceptor = LoggingTlsAcceptor::new(tls);
+    let https_server = axum_server::from_tcp(https_listener)?
+        .acceptor(https_acceptor)
+        .handle(h2);
+    let https_shutdown = shutdown_requested.clone();
+    let https = tokio::spawn(supervise_server(
+        "HTTPS",
+        https_shutdown,
+        https_server.serve(app_https.into_make_service()),
+    ));
 
-    tracing::info!(%http_addr, %https_addr, "manifest servers up");
+    tracing::info!(%http_addr, %https_addr, "manifest servers ready; both sockets bound");
 
     Ok(ServerHandles {
         http,
         https,
         http_handle,
         https_handle,
+        shutdown_requested,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+    use tower::ServiceExt;
+
+    const TEST_FIRMWARE_SIZE: u64 = 446_736;
+    const BISCUIT_FIRMWARE_URL: &str =
+        "https://unlocker.crosspointreader.com/firmware/firmware.bin";
+
+    fn test_config(crosspet_http: bool) -> Arc<ServerConfig> {
+        Arc::new(ServerConfig {
+            bridge_ip: "192.168.137.1".to_string(),
+            bind_ip: "192.168.137.1".parse().unwrap(),
+            model: Model::X4,
+            locale: Locale::English,
+            firmware_path: PathBuf::from("firmware.bin"),
+            firmware_size: TEST_FIRMWARE_SIZE,
+            firmware_sha256: "00".repeat(32),
+            crosspoint_version: "test".to_string(),
+            change_log: "test".to_string(),
+            crosspet_http,
+            on_manifest_request: Arc::new(tokio::sync::Notify::new()),
+            on_firmware_streamed: Arc::new(tokio::sync::Notify::new()),
+        })
+    }
+
+    fn asset_urls(release: &serde_json::Value) -> Vec<&str> {
+        release["assets"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|asset| asset["browser_download_url"].as_str().unwrap())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn biscuit_manifest_is_exact_and_fixed_length() {
+        let response = router(test_config(false))
+            .oneshot(
+                AxRequest::builder()
+                    .uri("/repos/yattsu/biscuit/releases/latest")
+                    .header(header::HOST, "api.github.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/json"
+        );
+        assert!(response.headers().get(header::TRANSFER_ENCODING).is_none());
+
+        let declared_length: usize = response
+            .headers()
+            .get(header::CONTENT_LENGTH)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .parse()
+            .unwrap();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(declared_length, body.len());
+
+        let expected = serde_json::json!({
+            "tag_name": "99.9.9",
+            "name": "CrossPoint test",
+            "assets": [{
+                "name": "firmware.bin",
+                "browser_download_url": BISCUIT_FIRMWARE_URL,
+                "size": TEST_FIRMWARE_SIZE,
+                "content_type": "application/octet-stream",
+            }],
+        });
+        assert_eq!(body.as_ref(), serde_json::to_vec(&expected).unwrap());
+
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(parsed["tag_name"], "99.9.9");
+        let assets = parsed["assets"].as_array().unwrap();
+        assert_eq!(assets.len(), 1);
+        assert_eq!(assets[0]["name"], "firmware.bin");
+        assert_eq!(assets[0]["browser_download_url"], BISCUIT_FIRMWARE_URL);
+        assert_eq!(assets[0]["size"], TEST_FIRMWARE_SIZE);
+    }
+
+    #[tokio::test]
+    async fn stock_and_vcodex_routes_remain_unchanged() {
+        let app = router(test_config(false));
+        let stock_response = app
+            .clone()
+            .oneshot(
+                AxRequest::builder()
+                    .uri("/api/v1/check-update")
+                    .header(header::HOST, "api-prod.xteink.cc")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let stock_body = to_bytes(stock_response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let stock: serde_json::Value = serde_json::from_slice(&stock_body).unwrap();
+        assert_eq!(stock["code"], 0);
+        assert_eq!(stock["data"]["version"], "V99.9.9");
+        assert_eq!(stock["data"]["size"], TEST_FIRMWARE_SIZE);
+        let stock_url = stock["data"]["download_url"].as_str().unwrap();
+        assert!(stock_url.starts_with("http://192.168.137.1/firmware/V99.9.9-X4-EN-PROD-"));
+        assert!(stock_url.ends_with(".bin"));
+
+        let vcodex_response = app
+            .oneshot(
+                AxRequest::builder()
+                    .uri("/cpr-vcodex/firmware/manifest.json")
+                    .header(header::HOST, "franssjz.github.io")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let vcodex_body = to_bytes(vcodex_response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let vcodex: serde_json::Value = serde_json::from_slice(&vcodex_body).unwrap();
+        assert_eq!(vcodex["version"], "99.9.9");
+        assert_eq!(
+            vcodex["downloadUrl"],
+            "http://unlocker.crosspointreader.com/firmware/firmware.bin"
+        );
+        assert_eq!(vcodex["size"], TEST_FIRMWARE_SIZE);
+    }
+
+    #[test]
+    fn biscuit_detection_does_not_change_other_repo_manifests() {
+        let cfg = test_config(false);
+
+        let biscuit = build_release(&cfg, "biscuit");
+        assert_eq!(asset_urls(&biscuit), vec![BISCUIT_FIRMWARE_URL]);
+
+        let crosspoint = build_release(&cfg, "crosspoint-reader");
+        assert_eq!(crosspoint["tag_name"], "99.9.9");
+        assert_eq!(
+            asset_urls(&crosspoint),
+            vec!["http://unlocker.crosspointreader.com/firmware/firmware.bin"]
+        );
+        assert_eq!(crosspoint["assets"][0]["name"], "firmware.bin");
+
+        let inx = build_release(&cfg, "inx");
+        assert_eq!(
+            asset_urls(&inx),
+            vec!["https://unlocker.crosspointreader.com/firmware/firmware.bin"]
+        );
+
+        let crosspet = build_release(&cfg, "crosspet");
+        assert_eq!(
+            asset_urls(&crosspet),
+            vec!["https://unlocker.crosspointreader.com/firmware/firmware.bin"]
+        );
+        let crosspet_http = build_release(&test_config(true), "crosspet");
+        assert_eq!(
+            asset_urls(&crosspet_http),
+            vec!["http://unlocker.crosspointreader.com/firmware/firmware.bin"]
+        );
+
+        let crossink = build_release(&cfg, "crossink");
+        let crossink_assets = crossink["assets"].as_array().unwrap();
+        assert_eq!(crossink_assets.len(), 3);
+        assert_eq!(
+            crossink_assets[0]["name"],
+            "firmware-no_emoji-v99.9.9.1.bin"
+        );
+        assert!(asset_urls(&crossink)
+            .iter()
+            .all(|url| url.starts_with("http://")));
+
+        let similarly_named_repo = build_release(&cfg, "biscuit-next");
+        assert_eq!(
+            asset_urls(&similarly_named_repo),
+            vec!["http://unlocker.crosspointreader.com/firmware/firmware.bin"]
+        );
+    }
+
+    #[test]
+    fn esp32c3_image_chip_id_is_five() {
+        assert_eq!(esp_chip_name(0x0005), Some("ESP32-C3"));
+        assert_eq!(esp_chip_name(0x0009), Some("ESP32-S3"));
+        assert_eq!(esp_chip_name(0x0006), None);
+    }
 }


### PR DESCRIPTION
## Summary

Adds explicit OTA support for Biscuit and exposes TCP/TLS failures that
currently happen before the Unlocker's normal HTTP request logging.

## Background

An XTEINK X4 running Biscuit successfully joins the Unlocker hotspot and
resolves `api.github.com` to `192.168.137.1`, but Biscuit reports
`Update failed` and the existing helper logs no GitHub manifest request.

The previous Unlocker could report its servers as ready before ports 80 and
443 had successfully bound. TLS handshake failures occurring before Axum were
also not logged.

Separately, Biscuit requires an HTTPS OTA download URL. The generic Unlocker
response previously supplied Biscuit with an HTTP firmware URL.

## Changes

- bind HTTP and HTTPS sockets before reporting readiness
- return and log bind failures
- log incoming HTTPS TCP connections and client addresses
- log TLS handshake start, success and available failure details
- log negotiated TLS version, cipher, ALPN and successful-handshake SNI
- supervise unexpected server exits and task failures
- add a Biscuit-only release manifest containing:
  - `tag_name` exactly `99.9.9`
  - exactly one asset named `firmware.bin`
  - the selected firmware's exact byte size
  - `https://unlocker.crosspointreader.com/firmware/firmware.bin`
  - explicit JSON `Content-Length`
  - no chunked transfer encoding
- preserve existing stock Xteink, CrossPoint, CrossInk, INX, CrossPet and
  CPR-vCodex behaviour
- correct the diagnostic ESP32-C3 chip ID mapping
- add focused response and compatibility tests
- document the Stage A and Stage B findings and Escape Hatch verification

## Validation

- `cargo fmt -p unlocker-core -- --check`
- `cargo test --locked -p unlocker-core` — 4 passed
- `cargo check --locked -p unlocker-core`
- `cargo clippy --locked -p unlocker-core --all-targets`
- `git diff --check`

The public repository omits the production `privkey.pem`, so no helper or
installer build was attempted. No replacement key, self-signed certificate
or TLS bypass was introduced.

## Certificate action required

The certificate currently committed in `fullchain.pem` expires on
2026-07-30. Any Windows test installer must use a currently valid
`unlocker.crosspointreader.com` certificate, complete chain and the
maintainers' legitimate matching private key.

## Maintainer test request

Please produce a Windows test installer using the legitimate renewed
certificate infrastructure.

For the first device test:

1. Select X4.
2. Select the verified Escape Hatch recovery image.
3. Start the hotspot and confirm ports 80 and 443 bind successfully.
4. Connect the Biscuit device.
5. Run `Check for Updates` once.
6. Save the complete helper log.
7. Do not confirm installation until the selected firmware image, SHA-256,
   size, ESP32-C3 chip ID and returned manifest have been verified.