### PR TITLE
Add per-device (X3/X4) show/hide for betas and official releases

### DIFF
--- a/src/components/DownloadModal.jsx
+++ b/src/components/DownloadModal.jsx
@@ -1,5 +1,11 @@
 import { useEffect, useMemo, useState } from 'react'
 import Modal from './Modal.jsx'
+import { fetchReleaseVisibility, fetchBetaBuilds } from '../lib/flasher.js'
+
+// Maps catalog channels to the release-visibility keys the admin panel uses.
+// Only the "real" stable release maps to `crosspoint`; recovery entries
+// (channel 'stable', id 'recovery-*') are left alone.
+const CHANNEL_VISIBILITY_KEY = { insider: 'nightly', 'stock-en': 'stock-en', 'stock-ch': 'stock-ch' }
 
 // Download .bin modal: device picker + firmware picker (from /api/catalog) → download.
 
@@ -40,6 +46,12 @@ function formatSize(bytes) {
 export default function DownloadModal({ open, onClose }) {
   const [model, setModel] = useState(null)
   const [catalog, setCatalog] = useState(null)
+  // Per-device visibility, matching the homepage flasher. `visibility.hidden`
+  // covers the fixed release/stock channels; `betaHidden` maps a beta id to the
+  // devices it's hidden on. Both default to "nothing hidden" so a fetch failure
+  // never blanks the list.
+  const [visibility, setVisibility] = useState({ hidden: {} })
+  const [betaHidden, setBetaHidden] = useState({})
   const [loadError, setLoadError] = useState(null)
   const [selectedId, setSelectedId] = useState(null)
   const [status, setStatus] = useState({ text: '', error: false })
@@ -68,19 +80,55 @@ export default function DownloadModal({ open, onClose }) {
     }
   }, [open, catalog])
 
-  // Order: stable, insider, betas, stock (newest first).
+  // Load per-device visibility (release toggles + beta hiddenDevices) once the
+  // modal opens, so the list matches what the homepage flasher shows.
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    fetchReleaseVisibility()
+      .then((v) => {
+        if (!cancelled && v) setVisibility(v)
+      })
+      .catch(() => {})
+    fetchBetaBuilds()
+      .then((builds) => {
+        if (cancelled || !Array.isArray(builds)) return
+        const map = {}
+        builds.forEach((b) => {
+          if (b.hiddenDevices && b.hiddenDevices.length) map[b.id] = b.hiddenDevices
+        })
+        setBetaHidden(map)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [open])
+
+  // Order: stable, insider, betas, stock (newest first). Options hidden for the
+  // selected device (via the admin panel) are filtered out first.
   const releases = useMemo(() => {
     if (!model || !catalog) return []
-    const base = (catalog.releases || []).filter(
-      (r) => !r.supported_devices || r.supported_devices.includes(model)
-    )
-    return [...base, ...stockReleases(model)].sort((a, b) => {
+    const hidden = visibility.hidden || {}
+    const isHidden = (key) => (hidden[key] || []).includes(model)
+    const base = (catalog.releases || []).filter((r) => {
+      if (r.supported_devices && !r.supported_devices.includes(model)) return false
+      if (r.channel === 'beta') return !(betaHidden[r.id] || []).includes(model)
+      // Only the real stable release honors the crosspoint toggle; recovery
+      // entries (id 'recovery-*') stay visible regardless.
+      if (r.channel === 'stable' && r.id.startsWith('stable-')) return !isHidden('crosspoint')
+      const key = CHANNEL_VISIBILITY_KEY[r.channel]
+      if (key) return !isHidden(key)
+      return true
+    })
+    const stock = stockReleases(model).filter((r) => !isHidden(r.channel))
+    return [...base, ...stock].sort((a, b) => {
       const ca = CHANNEL_ORDER[a.channel] ?? 99
       const cb = CHANNEL_ORDER[b.channel] ?? 99
       if (ca !== cb) return ca - cb
       return (b.released_at || '').localeCompare(a.released_at || '')
     })
-  }, [model, catalog])
+  }, [model, catalog, visibility, betaHidden])
 
   // Default to the latest stable release (falling back to the top of the list,
   // e.g. for X3 which has no stable build) so SD flashing is one click away.

--- a/src/lib/flasher.js
+++ b/src/lib/flasher.js
@@ -1076,6 +1076,20 @@ export async function fetchBetaBuilds() {
   return data.builds || [];
 }
 
+// Per-device visibility for the fixed release buttons (crosspoint, nightly,
+// stock-en, stock-ch) on x3/x4. Returns { hidden: { [key]: ['x3'|'x4'] } }.
+// Falls back to "nothing hidden" so a fetch failure never blanks the flasher.
+export async function fetchReleaseVisibility() {
+  try {
+    const res = await fetch('/api/release-visibility')
+    if (!res.ok) return { hidden: {} }
+    const data = await res.json()
+    return { hidden: data.hidden || {} }
+  } catch {
+    return { hidden: {} }
+  }
+}
+
 export async function fetchBetaFirmware(id) {
   const res = await fetch(`/api/beta/${id}/firmware`);
   if (!res.ok) throw new Error(`Failed to download beta firmware: ${res.status}`);

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -70,6 +70,64 @@ function ArrowDownIcon() {
   )
 }
 
+// --- Per-device visibility (x3 / x4) -----------------------------------
+// The web flasher shows every firmware option on both Xteink models by
+// default; these controls let an admin hide individual betas or official
+// release buttons on a specific device.
+
+const FIRMWARE_DEVICES = [
+  { id: 'x3', label: 'X3' },
+  { id: 'x4', label: 'X4' },
+]
+
+// The fixed release buttons the flasher renders for x3/x4. Keys match the
+// `action` ids in FlashTools.jsx and OFFICIAL_RELEASE_KEYS in the worker.
+const OFFICIAL_RELEASES = [
+  { key: 'crosspoint', label: 'CrossPoint', sub: 'Community · stable release' },
+  { key: 'nightly', label: 'CrossPoint Nightly', sub: 'Insider' },
+  { key: 'stock-en', label: 'Stock English', sub: 'Official' },
+  { key: 'stock-ch', label: 'Stock Chinese', sub: 'Official' },
+]
+
+// Checkbox pair ("Show on X3 / X4") driven by a hiddenDevices list. Both
+// boxes checked = shown on both devices (empty hiddenDevices).
+function DeviceVisibilityToggles({ hiddenDevices, onChange }) {
+  const hidden = hiddenDevices || []
+  return (
+    <div className="flex items-center gap-4">
+      <span className="text-xs font-medium text-stone-500">Show on:</span>
+      {FIRMWARE_DEVICES.map((d) => {
+        const shown = !hidden.includes(d.id)
+        return (
+          <label key={d.id} className="flex items-center gap-1.5 text-sm text-stone-700">
+            <input
+              type="checkbox"
+              checked={shown}
+              onChange={(e) =>
+                onChange(
+                  e.target.checked ? hidden.filter((x) => x !== d.id) : [...hidden, d.id]
+                )
+              }
+              className="size-4 rounded border-stone-300 text-brand-500 focus:ring-brand-500/20"
+            />
+            {d.label}
+          </label>
+        )
+      })}
+    </div>
+  )
+}
+
+// Compact label describing where an item is visible, or null when it's shown
+// everywhere (the default, so no badge is needed).
+function visibilityLabel(hiddenDevices) {
+  const hidden = hiddenDevices || []
+  const shown = FIRMWARE_DEVICES.filter((d) => !hidden.includes(d.id))
+  if (shown.length === FIRMWARE_DEVICES.length) return null
+  if (shown.length === 0) return 'hidden on all'
+  return shown.map((d) => d.label).join(', ') + ' only'
+}
+
 // --- Current build status ----------------------------------------------
 
 function BuildStatusCard({ log, refreshRef }) {
@@ -748,6 +806,7 @@ function BetaCard({ secret, log }) {
   const [file, setFile] = useState(null)
   const [releaseTag, setReleaseTag] = useState('')
   const [releaseRepo, setReleaseRepo] = useState('')
+  const [hiddenDevices, setHiddenDevices] = useState([])
   const [busy, setBusy] = useState(false)
   const [builds, setBuilds] = useState([])
   // Per-build edit panels: { [id]: { name, notes, tag, repo } }
@@ -792,6 +851,7 @@ function BetaCard({ secret, log }) {
       const formData = new FormData()
       formData.append('name', trimmedName)
       formData.append('notes', notes.trim())
+      formData.append('hiddenDevices', JSON.stringify(hiddenDevices))
       if (isRelease) {
         formData.append('releaseTag', tag)
         if (repo) formData.append('releaseRepo', repo)
@@ -819,6 +879,7 @@ function BetaCard({ secret, log }) {
         setFile(null)
         if (fileInputRef.current) fileInputRef.current.value = ''
         setReleaseTag('')
+        setHiddenDevices([])
         loadBetaList()
       } else {
         log('Beta create failed: ' + data.error)
@@ -855,7 +916,13 @@ function BetaCard({ secret, log }) {
       } else {
         // Don't pre-fill the tag; leaving it blank means "keep current binary".
         // Pre-filling would force a re-fetch on every save.
-        next[b.id] = { name: b.name, notes: b.notes || '', tag: '', repo: '' }
+        next[b.id] = {
+          name: b.name,
+          notes: b.notes || '',
+          tag: '',
+          repo: '',
+          hiddenDevices: b.hiddenDevices || [],
+        }
       }
       return next
     })
@@ -874,7 +941,7 @@ function BetaCard({ secret, log }) {
     const repo = edit.repo.trim()
     if (!editName) return
 
-    const body = { name: editName, notes: editNotes }
+    const body = { name: editName, notes: editNotes, hiddenDevices: edit.hiddenDevices || [] }
     if (tag) {
       body.releaseTag = tag
       if (repo) body.releaseRepo = repo
@@ -1010,6 +1077,10 @@ function BetaCard({ secret, log }) {
             </p>
           </div>
         )}
+
+        <div className="pt-1">
+          <DeviceVisibilityToggles hiddenDevices={hiddenDevices} onChange={setHiddenDevices} />
+        </div>
       </div>
 
       {builds.length > 0 && (
@@ -1021,6 +1092,7 @@ function BetaCard({ secret, log }) {
             const currentTag = src ? src.tag : ''
             const currentRepo = src ? src.owner + '/' + src.repo : ''
             const edit = edits[b.id]
+            const visLabel = visibilityLabel(b.hiddenDevices)
             return (
               <div key={b.id} className="py-2.5">
                 <div className="flex items-center justify-between">
@@ -1041,6 +1113,12 @@ function BetaCard({ secret, log }) {
                           <span className="text-stone-500" title={b.notes}>
                             has notes
                           </span>
+                        </>
+                      )}
+                      {visLabel && (
+                        <>
+                          {' '}
+                          &middot; <span className="text-amber-600">{visLabel}</span>
                         </>
                       )}
                     </div>
@@ -1100,6 +1178,10 @@ function BetaCard({ secret, log }) {
                         Setting a tag refetches firmware.bin and replaces the stored binary.
                       </p>
                     </div>
+                    <DeviceVisibilityToggles
+                      hiddenDevices={edit.hiddenDevices}
+                      onChange={(next) => setEditField(b.id, 'hiddenDevices', next)}
+                    />
                     <div className="flex gap-2">
                       <button
                         type="button"
@@ -1124,6 +1206,104 @@ function BetaCard({ secret, log }) {
         </div>
       )}
       {builds.length === 0 && <p className="mt-3 text-xs text-stone-400">No beta builds</p>}
+    </Card>
+  )
+}
+
+// --- Official release visibility (x3 / x4) -----------------------------------
+// Per-device show/hide for the fixed release buttons the flasher renders for
+// the Xteink X3 and X4. Betas are controlled individually in the Beta Testing
+// card above.
+
+function ReleaseVisibilityCard({ secret, log }) {
+  const [hidden, setHidden] = useState({})
+  const [busy, setBusy] = useState(false)
+  const [result, setResult] = useState(null) // { ok, text }
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await fetch('/api/release-visibility')
+        if (!res.ok) return
+        const data = await res.json()
+        if (!cancelled) setHidden(data.hidden || {})
+      } catch {
+        log('Failed to load release visibility')
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [log])
+
+  function setReleaseHidden(key, next) {
+    setHidden((prev) => {
+      const copy = { ...prev }
+      if (next.length) copy[key] = next
+      else delete copy[key]
+      return copy
+    })
+  }
+
+  async function save() {
+    setBusy(true)
+    setResult(null)
+    try {
+      const res = await fetch('/api/release-visibility', {
+        method: 'PUT',
+        headers: {
+          Authorization: 'Bearer ' + secret,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ hidden }),
+      })
+      if (res.ok) {
+        setResult({ ok: true, text: 'Saved' })
+        log('Release visibility saved')
+      } else {
+        const data = await res.json().catch(() => ({}))
+        setResult({ ok: false, text: data.error || 'Save failed' })
+      }
+    } catch {
+      setResult({ ok: false, text: 'Connection error' })
+    }
+    setBusy(false)
+  }
+
+  return (
+    <Card>
+      <CardTitle>Release Visibility</CardTitle>
+      <p className="mt-1 text-xs text-stone-400">
+        Show or hide each official firmware option on the{' '}
+        <Link to="/" className="font-medium text-brand-500 underline underline-offset-2">
+          homepage flasher
+        </Link>{' '}
+        per device (X3 / X4). Unchecking a box hides that option on that device. Individual betas
+        are controlled in the Beta Testing card above.
+      </p>
+
+      <div className="mt-3 divide-y divide-stone-100">
+        {OFFICIAL_RELEASES.map((r) => (
+          <div key={r.key} className="flex items-center justify-between gap-3 py-2.5">
+            <div className="min-w-0 flex-1">
+              <div className="text-sm font-medium text-stone-700">{r.label}</div>
+              <div className="text-xs text-stone-400">{r.sub}</div>
+            </div>
+            <DeviceVisibilityToggles
+              hiddenDevices={hidden[r.key]}
+              onChange={(next) => setReleaseHidden(r.key, next)}
+            />
+          </div>
+        ))}
+      </div>
+
+      <Button as="button" variant="primary" className="mt-3 w-full" onClick={save} disabled={busy}>
+        {busy ? 'Saving...' : 'Save visibility'}
+      </Button>
+      {result && (
+        <p className={`mt-2 text-xs ${result.ok ? 'text-brand-600' : 'text-red-600'}`}>{result.text}</p>
+      )}
     </Card>
   )
 }
@@ -1492,6 +1672,7 @@ export default function AdminPage() {
             <BannerCard secret={secret} log={log} />
             <AccessoriesCard secret={secret} log={log} />
             <BetaCard secret={secret} log={log} />
+            <ReleaseVisibilityCard secret={secret} log={log} />
             <DeviceBuildCard
               secret={secret}
               log={log}

--- a/src/pages/home/FlashTools.jsx
+++ b/src/pages/home/FlashTools.jsx
@@ -11,6 +11,7 @@ import {
   fetchBuildMeta,
   fetchBetaBuilds,
   fetchBetaFirmware,
+  fetchReleaseVisibility,
   fetchDeviceBuildInfo,
   fetchDeviceBuildFirmware,
   fetchFlashAsset,
@@ -206,6 +207,10 @@ export default function FlashTools() {
   // Beta builds from /api (buttons inserted before "Custom .bin")
   const [betaBuilds, setBetaBuilds] = useState([])
 
+  // Per-device visibility for the fixed release buttons on x3/x4.
+  // { hidden: { crosspoint: ['x3'], ... } }
+  const [releaseVisibility, setReleaseVisibility] = useState({ hidden: {} })
+
   // Admin-uploaded build for DEVICE_BUILD_MODELS (sticky, m5paper, lilygo, x4pro)
   const [deviceBuild, setDeviceBuild] = useState(null)
 
@@ -253,12 +258,17 @@ export default function FlashTools() {
   const [restart, setRestart] = useState(null) // { unplug: bool }
   const progressRef = useRef(null)
 
-  // --- Load beta builds once ---
+  // --- Load beta builds + release visibility once ---
   useEffect(() => {
     let cancelled = false
     fetchBetaBuilds()
       .then((builds) => {
         if (!cancelled && Array.isArray(builds)) setBetaBuilds(builds)
+      })
+      .catch(() => {})
+    fetchReleaseVisibility()
+      .then((v) => {
+        if (!cancelled && v) setReleaseVisibility(v)
       })
       .catch(() => {})
     return () => {
@@ -602,6 +612,12 @@ export default function FlashTools() {
     setRunning(false)
   }
 
+  // Per-device visibility (only x3/x4 carry admin-controlled hiding). Betas
+  // hide via their own hiddenDevices list; the fixed release buttons hide via
+  // the release-visibility config keyed by action id.
+  const visibleBetas = betaBuilds.filter((b) => !(b.hiddenDevices || []).includes(model))
+  const isReleaseHidden = (key) => (releaseVisibility.hidden?.[key] || []).includes(model)
+
   const selectedBeta = fw?.startsWith('beta-') ? betaBuilds.find((b) => `beta-${b.id}` === fw) : null
 
   return (
@@ -705,25 +721,33 @@ export default function FlashTools() {
                 </div>
               ) : (
               <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3">
-                <button type="button" onClick={() => selectFw('crosspoint')} className={cardClass(fw === 'crosspoint')}>
-                  <div className="text-sm font-semibold text-stone-900">
-                    {crosspoint.tag ? `CrossPoint ${crosspoint.tag}` : 'CrossPoint'}
-                  </div>
-                  <div className="mt-0.5 font-mono text-xs text-brand-600">Community</div>
-                </button>
-                <button type="button" onClick={() => selectFw('nightly')} className={cardClass(fw === 'nightly')}>
-                  <div className="text-sm font-semibold text-stone-900">CrossPoint Nightly</div>
-                  <div className="mt-0.5 font-mono text-xs text-brand-600">Insider</div>
-                </button>
-                <button type="button" onClick={() => selectFw('stock-en')} className={cardClass(fw === 'stock-en')}>
-                  <div className="text-sm font-semibold text-stone-900">Stock English</div>
-                  <div className="mt-0.5 font-mono text-xs text-stone-400">Official</div>
-                </button>
-                <button type="button" onClick={() => selectFw('stock-ch')} className={cardClass(fw === 'stock-ch')}>
-                  <div className="text-sm font-semibold text-stone-900">Stock Chinese</div>
-                  <div className="mt-0.5 font-mono text-xs text-stone-400">Official</div>
-                </button>
-                {betaBuilds.map((b) => (
+                {!isReleaseHidden('crosspoint') && (
+                  <button type="button" onClick={() => selectFw('crosspoint')} className={cardClass(fw === 'crosspoint')}>
+                    <div className="text-sm font-semibold text-stone-900">
+                      {crosspoint.tag ? `CrossPoint ${crosspoint.tag}` : 'CrossPoint'}
+                    </div>
+                    <div className="mt-0.5 font-mono text-xs text-brand-600">Community</div>
+                  </button>
+                )}
+                {!isReleaseHidden('nightly') && (
+                  <button type="button" onClick={() => selectFw('nightly')} className={cardClass(fw === 'nightly')}>
+                    <div className="text-sm font-semibold text-stone-900">CrossPoint Nightly</div>
+                    <div className="mt-0.5 font-mono text-xs text-brand-600">Insider</div>
+                  </button>
+                )}
+                {!isReleaseHidden('stock-en') && (
+                  <button type="button" onClick={() => selectFw('stock-en')} className={cardClass(fw === 'stock-en')}>
+                    <div className="text-sm font-semibold text-stone-900">Stock English</div>
+                    <div className="mt-0.5 font-mono text-xs text-stone-400">Official</div>
+                  </button>
+                )}
+                {!isReleaseHidden('stock-ch') && (
+                  <button type="button" onClick={() => selectFw('stock-ch')} className={cardClass(fw === 'stock-ch')}>
+                    <div className="text-sm font-semibold text-stone-900">Stock Chinese</div>
+                    <div className="mt-0.5 font-mono text-xs text-stone-400">Official</div>
+                  </button>
+                )}
+                {visibleBetas.map((b) => (
                   <button
                     key={b.id}
                     type="button"

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,4 +1,4 @@
-import type { Env, BuildMetadata, CustomBuildMetadata, FontBuildMetadata, ThemeBuildMetadata, FontTree, FontFile, BetaBuild, BetaSource, Accessory } from './types';
+import type { Env, BuildMetadata, CustomBuildMetadata, FontBuildMetadata, ThemeBuildMetadata, FontTree, FontFile, BetaBuild, BetaSource, Accessory, FirmwareDevice, ReleaseVisibility } from './types';
 
 const ROYALTY_REPO_ID = 'SoFriendly/crosspoint-tools';
 
@@ -227,6 +227,11 @@ async function handleApi(
       case '/api/beta':
         if (request.method === 'GET') return handleBetaList(env, corsHeaders);
         if (request.method === 'POST') return handleBetaCreate(request, env, corsHeaders);
+        return json({ error: 'Method not allowed' }, 405, corsHeaders);
+
+      case '/api/release-visibility':
+        if (request.method === 'GET') return handleReleaseVisibilityGet(env, corsHeaders);
+        if (request.method === 'PUT') return handleReleaseVisibilityUpdate(request, env, corsHeaders);
         return json({ error: 'Method not allowed' }, 405, corsHeaders);
 
       case '/api/banner':
@@ -2922,6 +2927,91 @@ async function handleBetaList(
   return json({ builds: list }, 200, headers);
 }
 
+// --- Per-device firmware visibility (x3 / x4) ---
+//
+// The web flasher shows every release/nightly/stock button and every beta on
+// both Xteink models by default. The admin panel can hide individual options
+// per device: betas carry a `hiddenDevices` list on their own record, and the
+// fixed "official release" buttons are tracked in a single KV blob keyed by
+// release key -> hidden devices.
+
+const RELEASE_VISIBILITY_KEY = 'release-visibility';
+const FIRMWARE_DEVICES: FirmwareDevice[] = ['x3', 'x4'];
+// Keys for the fixed release buttons the flasher renders for x3/x4. Kept in
+// sync with the `action` ids used in FlashTools.jsx.
+const OFFICIAL_RELEASE_KEYS = ['crosspoint', 'nightly', 'stock-en', 'stock-ch'];
+
+// Coerce an arbitrary value into a clean list of known firmware devices.
+// Accepts an array (from JSON bodies) or a comma-separated string (from
+// multipart form fields). Unknown/duplicate entries are dropped.
+function parseHiddenDevices(value: unknown): FirmwareDevice[] {
+  let raw: unknown[] = [];
+  if (Array.isArray(value)) {
+    raw = value;
+  } else if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return [];
+    try {
+      const parsed = JSON.parse(trimmed);
+      raw = Array.isArray(parsed) ? parsed : [];
+    } catch {
+      raw = trimmed.split(',');
+    }
+  }
+  const out: FirmwareDevice[] = [];
+  for (const entry of raw) {
+    const id = typeof entry === 'string' ? entry.trim() : '';
+    if (FIRMWARE_DEVICES.includes(id as FirmwareDevice) && !out.includes(id as FirmwareDevice)) {
+      out.push(id as FirmwareDevice);
+    }
+  }
+  return out;
+}
+
+async function getReleaseVisibility(env: Env): Promise<ReleaseVisibility> {
+  const raw = await env.BUILD_META.get(RELEASE_VISIBILITY_KEY);
+  const parsed = raw ? (JSON.parse(raw) as Partial<ReleaseVisibility>) : null;
+  const hidden: Record<string, FirmwareDevice[]> = {};
+  if (parsed && parsed.hidden && typeof parsed.hidden === 'object') {
+    for (const key of OFFICIAL_RELEASE_KEYS) {
+      const devices = parseHiddenDevices((parsed.hidden as Record<string, unknown>)[key]);
+      if (devices.length) hidden[key] = devices;
+    }
+  }
+  return { hidden };
+}
+
+async function handleReleaseVisibilityGet(
+  env: Env,
+  headers: Record<string, string>
+): Promise<Response> {
+  const visibility = await getReleaseVisibility(env);
+  return json(visibility, 200, headers);
+}
+
+async function handleReleaseVisibilityUpdate(
+  request: Request,
+  env: Env,
+  headers: Record<string, string>
+): Promise<Response> {
+  if (!isAuthorizedWebhookRequest(request, env)) {
+    return json({ error: 'Unauthorized' }, 401, headers);
+  }
+
+  const body = await request.json().catch(() => null) as { hidden?: Record<string, unknown> } | null;
+  const incoming = body && body.hidden && typeof body.hidden === 'object' ? body.hidden : {};
+
+  const hidden: Record<string, FirmwareDevice[]> = {};
+  for (const key of OFFICIAL_RELEASE_KEYS) {
+    const devices = parseHiddenDevices(incoming[key]);
+    if (devices.length) hidden[key] = devices;
+  }
+
+  const visibility: ReleaseVisibility = { hidden };
+  await env.BUILD_META.put(RELEASE_VISIBILITY_KEY, JSON.stringify(visibility));
+  return json(visibility, 200, headers);
+}
+
 // Resolve a tag on crosspoint-reader to a firmware.bin (or first *.bin) asset
 // and stream it back. Used by beta builds whose source is a GitHub release.
 async function fetchReleaseFirmware(
@@ -3021,6 +3111,8 @@ async function handleBetaCreate(
     customMetadata: { sha256 },
   });
 
+  const hiddenDevices = parseHiddenDevices(formData.get('hiddenDevices'));
+
   const build: BetaBuild = {
     id,
     name: name.trim(),
@@ -3030,6 +3122,7 @@ async function handleBetaCreate(
     firmwareSize: data.byteLength,
     firmwareSha256: sha256,
     source,
+    ...(hiddenDevices.length ? { hiddenDevices } : {}),
   };
 
   const list = await getBetaList(env);
@@ -3062,6 +3155,7 @@ async function handleBetaUpdate(
     notes?: string;
     releaseTag?: string;
     releaseRepo?: string;
+    hiddenDevices?: unknown;
   };
 
   if (body.name !== undefined) {
@@ -3072,6 +3166,11 @@ async function handleBetaUpdate(
   }
   if (body.notes !== undefined) {
     build.notes = typeof body.notes === 'string' ? body.notes.trim() : '';
+  }
+  if (body.hiddenDevices !== undefined) {
+    const hiddenDevices = parseHiddenDevices(body.hiddenDevices);
+    if (hiddenDevices.length) build.hiddenDevices = hiddenDevices;
+    else delete build.hiddenDevices;
   }
 
   // Re-link to (or refresh from) a GitHub release. Replaces the R2 binary in place.

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -121,6 +121,10 @@ export type BetaSource =
   | { type: 'upload' }
   | { type: 'github-release'; owner: string; repo: string; tag: string; asset: string };
 
+// Xteink models that share the release/nightly/stock/beta catalog and can have
+// their firmware options hidden per-device from the admin panel.
+export type FirmwareDevice = 'x3' | 'x4';
+
 export interface BetaBuild {
   id: string;
   name: string;
@@ -131,6 +135,17 @@ export interface BetaBuild {
   firmwareSha256?: string;
   // Absent on legacy entries; treat undefined as { type: 'upload' }.
   source?: BetaSource;
+  // Devices on which this beta is hidden in the web flasher. Absent/empty means
+  // shown on every device (backwards-compatible with legacy entries).
+  hiddenDevices?: FirmwareDevice[];
+}
+
+// Per-device visibility for the fixed "official release" firmware buttons
+// (CrossPoint stable, Nightly, Stock English, Stock Chinese). Keyed by release
+// key; the value lists the devices on which that button is hidden. A missing
+// key or absent device means the button is shown.
+export interface ReleaseVisibility {
+  hidden: Record<string, FirmwareDevice[]>;
 }
 
 export interface Accessory {


### PR DESCRIPTION
Admin can now hide individual firmware options on a specific Xteink model
from the homepage web flasher:

- Beta builds carry a `hiddenDevices` list on their own record, set via
  "Show on X3/X4" checkboxes in the Beta Testing card (create + edit).
- The four fixed release buttons (CrossPoint, Nightly, Stock English,
  Stock Chinese) are controlled by a new Release Visibility card, backed
  by a `/api/release-visibility` GET/PUT endpoint (KV-stored).

Defaults are unchanged: with nothing hidden, every option shows on both
devices, so legacy beta records and fresh installs behave as before. The
catalog/MCP endpoint is intentionally left untouched.